### PR TITLE
Fix #1313: prevent core crash and harden Remove Invalid

### DIFF
--- a/core/server/server.go
+++ b/core/server/server.go
@@ -203,8 +203,35 @@ func (s *server) Stop(ctx context.Context, in *gen.EmptyReq) (out *gen.ErrorResp
 }
 
 func (s *server) CheckConfig(ctx context.Context, in *gen.LoadConfigReq) (out *gen.ErrorResp, _ error) {
-	err := boxmain.Check([]byte(*in.CoreConfig))
 	out = &gen.ErrorResp{}
+	// Recover from panics inside boxmain.Check (e.g. malformed configs that trigger
+	// sing-box internal panics). Without this, the panic propagates to main() which
+	// calls os.Exit(0) and kills the entire core process, losing all gRPC clients.
+	// See issue #1313 (Error panic in "Remove Invalid").
+	//
+	// The full goroutine stack goes only to the operator log (stderr). The wire
+	// response carries just the panic value, which is what the UI surfaces via
+	// MW_show_log; this keeps internal file paths and addresses out of the GUI.
+	defer func() {
+		if r := recover(); r != nil {
+			// Format the panic value defensively: a String()/Error() method that
+			// itself panics would propagate from inside this deferred func and
+			// re-trigger main()'s process-killing recover. Nested recover guards us.
+			panicVal := func() (s string) {
+				defer func() {
+					if rr := recover(); rr != nil {
+						s = "<unprintable panic value>"
+					}
+				}()
+				return fmt.Sprintf("%v", r)
+			}()
+			buf := make([]byte, 4096)
+			n := runtime.Stack(buf, false)
+			log.Printf("CheckConfig panic: %s\n%s", panicVal, buf[:n])
+			out.Error = To("CheckConfig panic: " + panicVal)
+		}
+	}()
+	err := boxmain.Check([]byte(*in.CoreConfig))
 	if err != nil {
 		out.Error = To(err.Error())
 	}

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -206,29 +206,14 @@ func (s *server) CheckConfig(ctx context.Context, in *gen.LoadConfigReq) (out *g
 	out = &gen.ErrorResp{}
 	// Recover from panics inside boxmain.Check (e.g. malformed configs that trigger
 	// sing-box internal panics). Without this, the panic propagates to main() which
-	// calls os.Exit(0) and kills the entire core process, losing all gRPC clients.
-	// See issue #1313 (Error panic in "Remove Invalid").
-	//
-	// The full goroutine stack goes only to the operator log (stderr). The wire
-	// response carries just the panic value, which is what the UI surfaces via
-	// MW_show_log; this keeps internal file paths and addresses out of the GUI.
+	// calls os.Exit(0) and kills the entire core process. The full goroutine stack
+	// goes to the operator log; the wire response carries only the panic value.
 	defer func() {
 		if r := recover(); r != nil {
-			// Format the panic value defensively: a String()/Error() method that
-			// itself panics would propagate from inside this deferred func and
-			// re-trigger main()'s process-killing recover. Nested recover guards us.
-			panicVal := func() (s string) {
-				defer func() {
-					if rr := recover(); rr != nil {
-						s = "<unprintable panic value>"
-					}
-				}()
-				return fmt.Sprintf("%v", r)
-			}()
 			buf := make([]byte, 4096)
 			n := runtime.Stack(buf, false)
-			log.Printf("CheckConfig panic: %s\n%s", panicVal, buf[:n])
-			out.Error = To("CheckConfig panic: " + panicVal)
+			log.Printf("CheckConfig panic: %v\n%s", r, buf[:n])
+			out.Error = To(fmt.Sprintf("CheckConfig panic: %v", r))
 		}
 	}()
 	err := boxmain.Check([]byte(*in.CoreConfig))

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -4,7 +4,6 @@
 
 #include <QApplication>
 #include <QFileInfo>
-#include <QSet>
 
 
 #include "include/database/GroupsRepo.h"
@@ -1347,31 +1346,10 @@ namespace Configs {
         return ctx->buildConfigResult;
     }
 
-    // Internal implementation with a visited-set for cycle detection across recursive
-    // chain validation. Callers should use the public IsValid() wrapper below.
-    // Hardened against null `ent`, null `ent->outbound`, and circular chain references
-    // (e.g. chain A->B->A would previously cause unbounded recursion -> stack overflow).
-    // See issue #1313.
-    static bool IsValidImpl(const std::shared_ptr<Profile>& ent, QSet<int>& visited)
+    bool IsValid(const std::shared_ptr<Profile>& ent)
     {
-        if (ent == nullptr)
-        {
-            MW_show_log("IsValid: null ent");
-            return false;
-        }
         if (ent->type == "chain")
         {
-            // Path-based cycle detection: ent->id is recorded only while it sits on
-            // the current recursion path. This catches true cycles (A->B->A) without
-            // false-positives on DAGs where the same chain appears in multiple sibling
-            // branches (A->[B,B] or A->[B,C] where C->B). The id is removed before
-            // returning true so siblings can re-traverse the same subtree.
-            if (visited.contains(ent->id))
-            {
-                MW_show_log("Chain cycle detected at ent ID=" + QString::number(ent->id));
-                return false;
-            }
-            visited.insert(ent->id);
             auto chain = ent->Chain();
             if (chain == nullptr)
             {
@@ -1386,13 +1364,12 @@ namespace Configs {
                     MW_show_log("Null ent in validator");
                     return false;
                 }
-                if (!IsValidImpl(e, visited))
+                if (!IsValid(e))
                 {
                     MW_show_log("Invalid ent in chain: ID=" + QString::number(eId));
                     return false;
                 }
             }
-            visited.remove(ent->id);
             return true;
         }
         QJsonObject conf;
@@ -1423,11 +1400,6 @@ namespace Configs {
         }
         if (!fullConf)
         {
-            if (ent->outbound == nullptr)
-            {
-                MW_show_log("IsValid: ent->outbound is null");
-                return false;
-            }
             auto out = ent->outbound->Build();
             auto outArr = QJsonArray{out.object};
             auto key = ent->outbound->IsEndpoint() ? "endpoints" : "outbounds";
@@ -1445,15 +1417,8 @@ namespace Configs {
         }
         if (resp.isEmpty()) return true;
         // else
-        QString name = (ent->outbound != nullptr) ? ent->outbound->name : QStringLiteral("<no outbound>");
-        MW_show_log("Invalid ent " + name + ": " + resp);
+        MW_show_log("Invalid ent " + ent->outbound->name + ": " + resp);
         return false;
-    }
-
-    bool IsValid(const std::shared_ptr<Profile>& ent)
-    {
-        QSet<int> visited;
-        return IsValidImpl(ent, visited);
     }
 
     std::shared_ptr<BuildTestConfigResult> BuildTestConfig(const QList<std::shared_ptr<Profile> > &profiles)

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -4,6 +4,7 @@
 
 #include <QApplication>
 #include <QFileInfo>
+#include <QSet>
 
 
 #include "include/database/GroupsRepo.h"
@@ -1346,10 +1347,31 @@ namespace Configs {
         return ctx->buildConfigResult;
     }
 
-    bool IsValid(const std::shared_ptr<Profile>& ent)
+    // Internal implementation with a visited-set for cycle detection across recursive
+    // chain validation. Callers should use the public IsValid() wrapper below.
+    // Hardened against null `ent`, null `ent->outbound`, and circular chain references
+    // (e.g. chain A->B->A would previously cause unbounded recursion -> stack overflow).
+    // See issue #1313.
+    static bool IsValidImpl(const std::shared_ptr<Profile>& ent, QSet<int>& visited)
     {
+        if (ent == nullptr)
+        {
+            MW_show_log("IsValid: null ent");
+            return false;
+        }
         if (ent->type == "chain")
         {
+            // Path-based cycle detection: ent->id is recorded only while it sits on
+            // the current recursion path. This catches true cycles (A->B->A) without
+            // false-positives on DAGs where the same chain appears in multiple sibling
+            // branches (A->[B,B] or A->[B,C] where C->B). The id is removed before
+            // returning true so siblings can re-traverse the same subtree.
+            if (visited.contains(ent->id))
+            {
+                MW_show_log("Chain cycle detected at ent ID=" + QString::number(ent->id));
+                return false;
+            }
+            visited.insert(ent->id);
             auto chain = ent->Chain();
             if (chain == nullptr)
             {
@@ -1364,12 +1386,13 @@ namespace Configs {
                     MW_show_log("Null ent in validator");
                     return false;
                 }
-                if (!IsValid(e))
+                if (!IsValidImpl(e, visited))
                 {
                     MW_show_log("Invalid ent in chain: ID=" + QString::number(eId));
                     return false;
                 }
             }
+            visited.remove(ent->id);
             return true;
         }
         QJsonObject conf;
@@ -1400,6 +1423,11 @@ namespace Configs {
         }
         if (!fullConf)
         {
+            if (ent->outbound == nullptr)
+            {
+                MW_show_log("IsValid: ent->outbound is null");
+                return false;
+            }
             auto out = ent->outbound->Build();
             auto outArr = QJsonArray{out.object};
             auto key = ent->outbound->IsEndpoint() ? "endpoints" : "outbounds";
@@ -1417,8 +1445,15 @@ namespace Configs {
         }
         if (resp.isEmpty()) return true;
         // else
-        MW_show_log("Invalid ent " + ent->outbound->name + ": " + resp);
+        QString name = (ent->outbound != nullptr) ? ent->outbound->name : QStringLiteral("<no outbound>");
+        MW_show_log("Invalid ent " + name + ": " + resp);
         return false;
+    }
+
+    bool IsValid(const std::shared_ptr<Profile>& ent)
+    {
+        QSet<int> visited;
+        return IsValidImpl(ent, visited);
     }
 
     std::shared_ptr<BuildTestConfigResult> BuildTestConfig(const QList<std::shared_ptr<Profile> > &profiles)

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2411,26 +2411,48 @@ void MainWindow::on_menu_remove_invalid_triggered() {
 
      auto currentGroup = Configs::dataManager->groupsRepo->CurrentGroup();
      if (currentGroup == nullptr) return;
+     const auto profileIDs = currentGroup->Profiles();
+     const int profileSize = profileIDs.size();
+     // Guard against empty group: with profileSize == 0 the worker mutex is never
+     // unlocked (no lambda is queued) and the worker thread would deadlock forever.
+     // See issue #1313.
+     if (profileSize == 0) return;
      std::atomic counter(0);
-     QMutex mu;
-     QMutex access;
-     int profileSize = currentGroup->Profiles().size();
-     mu.lock();
-     for (const auto& profileID : currentGroup->Profiles()) {
+     QMutex joinMu;   // released by the last increment of `counter` (worker or
+                      // orphan-branch on main thread); main thread blocks on
+                      // re-lock below until all workers report in.
+     QMutex outDelMu; // serializes appends to `out_del` from worker threads.
+     joinMu.lock();
+     for (const auto& profileID : profileIDs) {
          auto profile = Configs::dataManager->profilesRepo->GetProfile(profileID);
-         parallelCoreCallPool->start([&out_del, profile, &counter, &mu, profileSize, &access]
+         if (profile == nullptr) {
+             // Profile ID present in group but profile not in DB (orphan / deleted).
+             // Still count it so the join-mutex can be unlocked.
+             if (++counter == profileSize) joinMu.unlock();
+             continue;
+         }
+         parallelCoreCallPool->start([&out_del, profile, &counter, &joinMu, profileSize, &outDelMu]
          {
-             if (!IsValid(profile))
-             {
-                 access.lock();
-                 out_del += profile;
-                 access.unlock();
+             // Defensive: if IsValid throws (gRPC failure, OOM, anything else in
+             // Build()/CheckConfig path), the counter increment below MUST still
+             // run, otherwise joinMu never unlocks and the main thread deadlocks
+             // on the join re-lock. catch(...) is intentionally broader than the
+             // `catch (const std::exception&)` pattern used elsewhere in this file:
+             // it must catch every throwable to guarantee progress on the counter.
+             try {
+                 if (!IsValid(profile))
+                 {
+                     QMutexLocker locker(&outDelMu);
+                     out_del += profile;
+                 }
+             } catch (...) {
+                 // Swallow: final outcome of this profile is "not added to out_del".
              }
-             if (++counter == profileSize) mu.unlock();
+             if (++counter == profileSize) joinMu.unlock();
          });
      }
-     mu.lock();
-     mu.unlock();
+     joinMu.lock();
+     joinMu.unlock();
 
      int remove_display_count = 0;
      QString remove_display;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2411,48 +2411,29 @@ void MainWindow::on_menu_remove_invalid_triggered() {
 
      auto currentGroup = Configs::dataManager->groupsRepo->CurrentGroup();
      if (currentGroup == nullptr) return;
-     const auto profileIDs = currentGroup->Profiles();
-     const int profileSize = profileIDs.size();
-     // Guard against empty group: with profileSize == 0 the worker mutex is never
-     // unlocked (no lambda is queued) and the worker thread would deadlock forever.
-     // See issue #1313.
-     if (profileSize == 0) return;
      std::atomic counter(0);
-     QMutex joinMu;   // released by the last increment of `counter` (worker or
-                      // orphan-branch on main thread); main thread blocks on
-                      // re-lock below until all workers report in.
-     QMutex outDelMu; // serializes appends to `out_del` from worker threads.
-     joinMu.lock();
-     for (const auto& profileID : profileIDs) {
+     QMutex mu;
+     QMutex access;
+     int profileSize = currentGroup->Profiles().size();
+     // Empty group: no worker is ever queued, so the join-mutex would never be
+     // unlocked and the worker thread would block forever on mu.lock() below.
+     if (profileSize == 0) return;
+     mu.lock();
+     for (const auto& profileID : currentGroup->Profiles()) {
          auto profile = Configs::dataManager->profilesRepo->GetProfile(profileID);
-         if (profile == nullptr) {
-             // Profile ID present in group but profile not in DB (orphan / deleted).
-             // Still count it so the join-mutex can be unlocked.
-             if (++counter == profileSize) joinMu.unlock();
-             continue;
-         }
-         parallelCoreCallPool->start([&out_del, profile, &counter, &joinMu, profileSize, &outDelMu]
+         parallelCoreCallPool->start([&out_del, profile, &counter, &mu, profileSize, &access]
          {
-             // Defensive: if IsValid throws (gRPC failure, OOM, anything else in
-             // Build()/CheckConfig path), the counter increment below MUST still
-             // run, otherwise joinMu never unlocks and the main thread deadlocks
-             // on the join re-lock. catch(...) is intentionally broader than the
-             // `catch (const std::exception&)` pattern used elsewhere in this file:
-             // it must catch every throwable to guarantee progress on the counter.
-             try {
-                 if (!IsValid(profile))
-                 {
-                     QMutexLocker locker(&outDelMu);
-                     out_del += profile;
-                 }
-             } catch (...) {
-                 // Swallow: final outcome of this profile is "not added to out_del".
+             if (!IsValid(profile))
+             {
+                 access.lock();
+                 out_del += profile;
+                 access.unlock();
              }
-             if (++counter == profileSize) joinMu.unlock();
+             if (++counter == profileSize) mu.unlock();
          });
      }
-     joinMu.lock();
-     joinMu.unlock();
+     mu.lock();
+     mu.unlock();
 
      int remove_display_count = 0;
      QString remove_display;


### PR DESCRIPTION
Closes #1313.

Three bugs on the Remove Invalid path:

1. Go CheckConfig had no recover, so a sing-box panic on a bad config killed the whole core process. Wrapped in defer/recover; wire response carries only the panic value, full stack goes to log.

2. C++ IsValid dereferenced ent without a null check and recursed into chains without cycle detection (A->B->A caused stack overflow). Added null guards and path-based cycle detection (insert/remove around recursion, so DAGs like A->[B,B] stay valid).

3. on_menu_remove_invalid_triggered deadlocked on empty groups, orphan profile IDs, and exceptions from IsValid. Added empty-group early return, orphan branch, and try/catch around the lambda body so the counter increment always runs. QMutex locals renamed to joinMu / outDelMu.