### PR TITLE
Fix #1334: force-clear system proxy on exit when no profile is running

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1388,6 +1388,15 @@ void MainWindow::prepare_exit()
     Configs::dataManager->settingsRepo->prepare_exit = true;
     //
     set_spmode_system_proxy(false, false);
+    // Issue #1334: when no profile is running, set_spmode_system_proxy() skips its
+    // ClearSystemProxy() call (the `if (running)` branch), and the subsequent
+    // profile_stop() also no-ops (running == nullptr). Force-clear once here to
+    // cover that path. When a profile IS running, the normal flow already clears
+    // proxy twice (set_spmode_system_proxy + profile_stop_stage2), so skip the
+    // redundant call to avoid extra QProcess::execute invocations on Linux.
+    if (running == nullptr) {
+        set_system_proxy(true);
+    }
     if (Configs::dataManager->settingsRepo->system_dns_set) set_system_dns(false, false);
     RegisterHiddenMenuShortcuts(true);
     RegisterHotkey(true);

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1387,16 +1387,7 @@ void MainWindow::prepare_exit()
     }
     Configs::dataManager->settingsRepo->prepare_exit = true;
     //
-    set_spmode_system_proxy(false, false);
-    // Issue #1334: when no profile is running, set_spmode_system_proxy() skips its
-    // ClearSystemProxy() call (the `if (running)` branch), and the subsequent
-    // profile_stop() also no-ops (running == nullptr). Force-clear once here to
-    // cover that path. When a profile IS running, the normal flow already clears
-    // proxy twice (set_spmode_system_proxy + profile_stop_stage2), so skip the
-    // redundant call to avoid extra QProcess::execute invocations on Linux.
-    if (running == nullptr) {
-        set_system_proxy(true);
-    }
+    set_system_proxy(true);
     if (Configs::dataManager->settingsRepo->system_dns_set) set_system_dns(false, false);
     RegisterHiddenMenuShortcuts(true);
     RegisterHotkey(true);


### PR DESCRIPTION
Closes #1334.

prepare_exit() called set_spmode_system_proxy(false, false), which only clears the proxy via its 'if (running)' branch. If the user stopped the profile before exit (or had the flag on without ever starting a profile), the proxy stayed set in gsettings/kioslaverc.

Added one conditional set_system_proxy(true) in prepare_exit(), gated on running == nullptr. Normal running-profile exit already clears twice, so the conditional avoids redundant QProcess::execute on Linux.