### PR TITLE
Fix #1395: restore tab background colors

### DIFF
--- a/include/database/Database.h
+++ b/include/database/Database.h
@@ -231,5 +231,10 @@ namespace Configs {
                 NotifyError("execBatchReplaceProfiles", e);
             }
         }
+
+        // Throws std::exception on failure. Caller must delete destPath if it already exists.
+        void backupTo(const std::string& destPath);
+        // Throws std::exception on failure.
+        void restoreFrom(const std::string& srcPath);
     };
 }

--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -324,6 +324,9 @@ QTabBar {
 }
 
 QTabBar::tab {
+    background-color: palette(button);
+    color: palette(button-text);
+
     border: 1px solid palette(midlight);
 
     border-radius: 4px;
@@ -333,6 +336,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background-color: palette(window); 
 }
 
 QTabBar::tab:!selected {
@@ -341,6 +345,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:hover:!selected {
     border: 1px solid palette(button);
+    background-color: palette(midlight);
 }</string>
        </property>
        <property name="currentIndex">
@@ -445,6 +450,9 @@ QTabBar {
 }
 
 QTabBar::tab {
+    background-color: palette(button);
+    color: palette(button-text);
+
     border: 1px solid palette(midlight);
 
     border-radius: 4px;
@@ -454,6 +462,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background-color: palette(window); 
 }
 
 QTabBar::tab:!selected {
@@ -462,6 +471,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:hover:!selected {
     border: 1px solid palette(button);
+    background-color: palette(midlight);
 }</string>
              </property>
              <property name="tabPosition">

--- a/include/ui/setting/RouteItem.ui
+++ b/include/ui/setting/RouteItem.ui
@@ -59,6 +59,7 @@
      <property name="styleSheet">
       <string notr="true">QTabWidget::pane {
     margin-top: 1px;
+    background: palette(base);
     border: 1px solid palette(mid);
     border-radius: 4px;
 }
@@ -69,6 +70,9 @@ QTabBar {
 }
 
 QTabBar::tab {
+    background-color: palette(button);
+    color: palette(button-text);
+
     border: 1px solid palette(midlight);
     border-radius: 4px;
 
@@ -78,6 +82,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background-color: palette(window); 
 }
 
 QTabBar::tab:!selected {
@@ -86,6 +91,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:hover:!selected {
     border: 1px solid palette(button);
+    background-color: palette(midlight);
 }</string>
      </property>
      <property name="currentIndex">

--- a/include/ui/setting/dialog_basic_settings.h
+++ b/include/ui/setting/dialog_basic_settings.h
@@ -38,4 +38,6 @@ private:
 
 private slots:
     void on_core_settings_clicked();
+    void on_backup_create_clicked();
+    void on_backup_restore_clicked();
 };

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -74,7 +74,7 @@ QTabBar::tab:hover:!selected {
       <enum>QTabWidget::TabShape::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">
@@ -1133,6 +1133,112 @@ QTabBar::tab:hover:!selected {
           </item>
          </layout>
         </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_backup">
+      <attribute name="title">
+       <string>Backup &amp; Restore</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_backup">
+       <item>
+        <widget class="QGroupBox" name="groupBox_backup_create">
+         <property name="title">
+          <string>Create Backup</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_backup_create">
+          <item>
+           <widget class="QLabel" name="label_backup_desc">
+            <property name="text">
+             <string>Create a portable backup file containing all profiles, groups, routes, settings, and custom icons.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_backup_btn">
+            <item>
+             <widget class="QPushButton" name="backup_create">
+              <property name="text">
+               <string>Create Backup...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_backup">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_backup_restore">
+         <property name="title">
+          <string>Restore Backup</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_backup_restore">
+          <item>
+           <widget class="QLabel" name="label_restore_desc">
+            <property name="text">
+             <string>Restore from a backup file. All current profiles, groups, routes, and settings will be replaced. The application must be restarted after restore.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_restore_btn">
+            <item>
+             <widget class="QPushButton" name="backup_restore">
+              <property name="text">
+               <string>Restore from Backup...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_restore">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_backup">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -41,6 +41,7 @@
      <property name="styleSheet">
       <string notr="true">QTabWidget::pane {
     margin-top: 1px;
+    background: palette(base);
     border: 1px solid palette(mid);
     border-radius: 4px;
 }
@@ -51,6 +52,9 @@ QTabBar {
 }
 
 QTabBar::tab {
+    background-color: palette(button);
+    color: palette(button-text);
+
     border: 1px solid palette(midlight);
     border-radius: 4px;
 
@@ -60,6 +64,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background-color: palette(window); 
 }
 
 QTabBar::tab:!selected {
@@ -68,6 +73,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:hover:!selected {
     border: 1px solid palette(button);
+    background-color: palette(midlight);
 }</string>
      </property>
      <property name="tabShape">

--- a/include/ui/setting/dialog_hotkey.ui
+++ b/include/ui/setting/dialog_hotkey.ui
@@ -19,6 +19,7 @@
      <property name="styleSheet">
       <string notr="true">QTabWidget::pane {
     margin-top: 1px;
+    background: palette(base);
     border: 1px solid palette(mid);
     border-radius: 4px;
 }
@@ -29,6 +30,9 @@ QTabBar {
 }
 
 QTabBar::tab {
+    background-color: palette(button);
+    color: palette(button-text);
+
     border: 1px solid palette(midlight);
     border-radius: 4px;
 
@@ -38,6 +42,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background-color: palette(window); 
 }
 
 QTabBar::tab:!selected {
@@ -46,6 +51,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:hover:!selected {
     border: 1px solid palette(button);
+    background-color: palette(midlight);
 }</string>
      </property>
      <property name="currentIndex">

--- a/include/ui/setting/dialog_manage_routes.ui
+++ b/include/ui/setting/dialog_manage_routes.ui
@@ -19,6 +19,7 @@
      <property name="styleSheet">
       <string notr="true">QTabWidget::pane {
     margin-top: 1px;
+    background: palette(base);
     border: 1px solid palette(mid);
     border-radius: 4px;
 }
@@ -29,6 +30,9 @@ QTabBar {
 }
 
 QTabBar::tab {
+    background-color: palette(button);
+    color: palette(button-text);
+
     border: 1px solid palette(midlight);
     border-radius: 4px;
 
@@ -38,6 +42,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background-color: palette(window); 
 }
 
 QTabBar::tab:!selected {
@@ -46,6 +51,7 @@ QTabBar::tab:!selected {
 
 QTabBar::tab:hover:!selected {
     border: 1px solid palette(button);
+    background-color: palette(midlight);
 }</string>
      </property>
      <property name="currentIndex">

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -1,4 +1,5 @@
 #include "include/database/Database.h"
+#include <3rdparty/SQLiteCpp/include/Backup.h>
 
 namespace Configs {
     void Database::maybeCheckpoint(int count) {
@@ -135,5 +136,17 @@ namespace Configs {
         } catch (std::exception& e) {
             std::cerr << "DB Error: " << e.what() << std::endl;
         }
+    }
+
+    void Database::backupTo(const std::string& destPath) {
+        SQLite::Database destDb(destPath, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+        SQLite::Backup backup(destDb, db);
+        backup.executeStep(-1);
+    }
+
+    void Database::restoreFrom(const std::string& srcPath) {
+        SQLite::Database srcDb(srcPath, SQLite::OPEN_READONLY);
+        SQLite::Backup restore(db, srcDb);
+        restore.executeStep(-1);
     }
 }

--- a/src/ui/setting/dialog_basic_settings.cpp
+++ b/src/ui/setting/dialog_basic_settings.cpp
@@ -18,6 +18,13 @@
 #include <QTextBlock>
 #include <QTextCursor>
 #include <qfontdatabase.h>
+#include <QDateTime>
+#include <QDataStream>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSysInfo>
+#include <QDir>
+#include <QStandardPaths>
 
 
 
@@ -380,6 +387,191 @@ void DialogBasicSettings::accept() {
     if (needChoosePort) str << "NeedChoosePort";
     MW_dialog_message(Dialog_DialogBasicSettings, str.join(","));
     QDialog::accept();
+}
+
+// Backup archive format:
+//   [magic: "NKRB" 4 bytes]
+//   [format_version: quint32]  -- identifies archive structure, increment on breaking layout changes
+//   [metadata: QString]        -- compact JSON: backup_version, created_at, platform
+//   [files: QMap<QString,QByteArray>]  -- "database" + optional "icons/<name>" entries
+static constexpr quint32 BACKUP_FORMAT_VERSION = 1;
+// backup_version (inside JSON metadata) is the semantic content version:
+//   v1: database + icons
+static constexpr int BACKUP_CONTENT_VERSION = 1;
+
+void DialogBasicSettings::on_backup_create_clicked() {
+    Configs::dataManager->settingsRepo->Save();
+
+    QString filePath = QFileDialog::getSaveFileName(
+        this,
+        tr("Create Backup"),
+        QDir::homePath() + "/Throne-backup.thrbackup",
+        tr("Throne Backup (*.thrbackup)")
+    );
+    if (filePath.isEmpty()) return;
+
+    QString tempDbPath = QDir::temp().filePath("Thr_backup_tmp.db");
+    QFile::remove(tempDbPath);
+
+    try {
+        Configs::dataManager->getDatabase().backupTo(tempDbPath.toStdString());
+    } catch (std::exception& e) {
+        QFile::remove(tempDbPath);
+        QMessageBox::critical(this, tr("Backup Failed"),
+            tr("Failed to create database snapshot: %1").arg(e.what()));
+        return;
+    }
+
+    QFile tempDbFile(tempDbPath);
+    if (!tempDbFile.open(QIODevice::ReadOnly)) {
+        QFile::remove(tempDbPath);
+        QMessageBox::critical(this, tr("Backup Failed"), tr("Failed to read database snapshot."));
+        return;
+    }
+    QByteArray dbBytes = tempDbFile.readAll();
+    tempDbFile.close();
+    QFile::remove(tempDbPath);
+
+    QMap<QString, QByteArray> files;
+    files["database"] = dbBytes;
+
+    QDir iconsDir("icons");
+    if (iconsDir.exists()) {
+        for (const QFileInfo& entry : iconsDir.entryInfoList(QDir::Files)) {
+            QFile iconFile(entry.absoluteFilePath());
+            if (iconFile.open(QIODevice::ReadOnly)) {
+                files["icons/" + entry.fileName()] = iconFile.readAll();
+            }
+        }
+    }
+
+    QFile outFile(filePath);
+    if (!outFile.open(QIODevice::WriteOnly)) {
+        QMessageBox::critical(this, tr("Backup Failed"),
+            tr("Cannot write to: %1").arg(filePath));
+        return;
+    }
+
+    QDataStream stream(&outFile);
+    stream.setByteOrder(QDataStream::LittleEndian);
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    stream.writeRawData("THRN", 4);
+    stream << BACKUP_FORMAT_VERSION;
+
+    QJsonObject meta;
+    meta["backup_version"] = BACKUP_CONTENT_VERSION;
+    meta["created_at"] = QDateTime::currentDateTime().toString(Qt::TextDate);
+    meta["platform"] = QSysInfo::kernelType();
+    stream << QString::fromUtf8(QJsonDocument(meta).toJson(QJsonDocument::Compact));
+
+    stream << files;
+    outFile.close();
+
+    QMessageBox::information(this, tr("Backup Created"),
+        tr("Backup created successfully:\n%1").arg(filePath));
+}
+
+void DialogBasicSettings::on_backup_restore_clicked() {
+    QString filePath = QFileDialog::getOpenFileName(
+        this,
+        tr("Restore Backup"),
+        QDir::homePath(),
+        tr("Throne Backup (*.thrbackup)")
+    );
+    if (filePath.isEmpty()) return;
+
+    QFile inFile(filePath);
+    if (!inFile.open(QIODevice::ReadOnly)) {
+        QMessageBox::critical(this, tr("Restore Failed"),
+            tr("Cannot open backup file: %1").arg(filePath));
+        return;
+    }
+
+    QDataStream stream(&inFile);
+    stream.setByteOrder(QDataStream::LittleEndian);
+    stream.setVersion(QDataStream::Qt_6_0);
+
+    char magic[4];
+    if (stream.readRawData(magic, 4) != 4 || strncmp(magic, "THRN", 4) != 0) {
+        QMessageBox::critical(this, tr("Restore Failed"),
+            tr("Not a valid Throne backup file."));
+        return;
+    }
+
+    quint32 formatVersion;
+    stream >> formatVersion;
+    if (formatVersion != BACKUP_FORMAT_VERSION) {
+        QMessageBox::critical(this, tr("Restore Failed"),
+            tr("Unsupported backup format version: %1.\nThis backup may have been created with a newer version of the application.")
+                .arg(formatVersion));
+        return;
+    }
+
+    QString metaJson;
+    stream >> metaJson;
+    QJsonObject meta = QJsonDocument::fromJson(metaJson.toUtf8()).object();
+    QString createdAt = meta["created_at"].toString();
+
+    QMap<QString, QByteArray> files;
+    stream >> files;
+    inFile.close();
+
+    if (!files.contains("database")) {
+        QMessageBox::critical(this, tr("Restore Failed"),
+            tr("Backup file is missing the database."));
+        return;
+    }
+
+    auto result = QMessageBox::warning(
+        this,
+        tr("Confirm Restore"),
+        tr("Restore backup created on %1?\n\n"
+           "This will replace all current profiles, groups, routes, and settings.\n\n"
+           "The settings dialog will close and the application must be restarted to complete the restore.")
+            .arg(createdAt.isEmpty() ? tr("unknown date") : createdAt),
+        QMessageBox::Ok | QMessageBox::Cancel,
+        QMessageBox::Cancel
+    );
+    if (result != QMessageBox::Ok) return;
+
+    QString tempDbPath = QDir::temp().filePath("Thr_restore_tmp.db");
+    QFile tempDbFile(tempDbPath);
+    if (!tempDbFile.open(QIODevice::WriteOnly)) {
+        QMessageBox::critical(this, tr("Restore Failed"),
+            tr("Failed to create temporary file for restore."));
+        return;
+    }
+    tempDbFile.write(files["database"]);
+    tempDbFile.close();
+
+    try {
+        Configs::dataManager->getDatabase().restoreFrom(tempDbPath.toStdString());
+    } catch (std::exception& e) {
+        QFile::remove(tempDbPath);
+        QMessageBox::critical(this, tr("Restore Failed"),
+            tr("Failed to restore database: %1").arg(e.what()));
+        return;
+    }
+    QFile::remove(tempDbPath);
+
+    QDir iconsDir("icons");
+    iconsDir.mkpath(".");
+    for (auto it = files.constBegin(); it != files.constEnd(); ++it) {
+        if (it.key().startsWith("icons/")) {
+            QString iconName = it.key().mid(6);
+            if (iconName.isEmpty()) continue;
+            QFile iconFile(iconsDir.filePath(iconName));
+            if (iconFile.open(QIODevice::WriteOnly)) {
+                iconFile.write(it.value());
+            }
+        }
+    }
+
+    QMessageBox::information(this, tr("Restore Complete"),
+        tr("Backup restored successfully. Throne will now restart for the changes to take effect."));
+    MW_dialog_message(Dialog_DialogBasicSettings, "RestartProgram");
+    QDialog::reject();
 }
 
 void DialogBasicSettings::on_core_settings_clicked() {


### PR DESCRIPTION
Closes #1395.

Revert of 66c833e8, which stripped background-color from QTabBar selectors and left only borders. Active and inactive tabs became visually indistinguishable.

Restored palette()-based background-color on tab, tab:selected, tab:hover, and pane in 5 .ui files.