### PR TITLE
linux tun nosuid fallback

### DIFF
--- a/core/server/dispatch.go
+++ b/core/server/dispatch.go
@@ -119,6 +119,17 @@ func dispatch(methodName string, payload []byte) ([]byte, error) {
 		}
 		return proto.Marshal(resp)
 
+	case "Shutdown":
+		req := &gen.EmptyReq{}
+		if err := proto.Unmarshal(payload, req); err != nil {
+			return nil, err
+		}
+		resp, err := s.Shutdown(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		return proto.Marshal(resp)
+
 	case "CheckConfig":
 		req := &gen.LoadConfigReq{}
 		if err := proto.Unmarshal(payload, req); err != nil {

--- a/core/server/gen/libcore.proto
+++ b/core/server/gen/libcore.proto
@@ -6,6 +6,7 @@ option go_package = "./;gen";
 service LibcoreService {
   rpc Start(LoadConfigReq) returns (ErrorResp);
   rpc Stop(EmptyReq) returns (ErrorResp);
+  rpc Shutdown(EmptyReq) returns (ErrorResp);
   rpc CheckConfig(LoadConfigReq) returns (ErrorResp);
   rpc Test(TestReq) returns (TestResp);
   rpc StopTest(EmptyReq) returns (EmptyResp);

--- a/core/server/parentcheck/parentcheck.go
+++ b/core/server/parentcheck/parentcheck.go
@@ -37,6 +37,10 @@ func CheckParentProcess() {
 		return
 	}
 
+	if runtime.GOOS == "linux" && os.Getenv("THRONE_CORE_PKEXEC") == "1" && parentBase == "pkexec" {
+		return
+	}
+
 	if parentDir != selfDir || parentBase != "Throne" {
 		log.Fatalf("parent check failed: unexpected parent %q", parentPath)
 	}

--- a/core/server/server.go
+++ b/core/server/server.go
@@ -202,6 +202,15 @@ func (s *server) Stop(ctx context.Context, in *gen.EmptyReq) (out *gen.ErrorResp
 	return
 }
 
+func (s *server) Shutdown(ctx context.Context, in *gen.EmptyReq) (out *gen.ErrorResp, _ error) {
+	out, _ = s.Stop(ctx, in)
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		os.Exit(0)
+	}()
+	return
+}
+
 func (s *server) CheckConfig(ctx context.Context, in *gen.LoadConfigReq) (out *gen.ErrorResp, _ error) {
 	out = &gen.ErrorResp{}
 	// Recover from panics inside boxmain.Check (e.g. malformed configs that trigger

--- a/include/api/RPC.h
+++ b/include/api/RPC.h
@@ -20,6 +20,8 @@ namespace API {
 
         QString Stop(bool *rpcOK);
 
+        QString Shutdown(bool *rpcOK);
+
         libcore::QueryStatsResp QueryStats();
 
         libcore::TestResp Test(bool *rpcOK, const libcore::TestReq &request);

--- a/include/sys/Process.hpp
+++ b/include/sys/Process.hpp
@@ -18,7 +18,7 @@ namespace Configs_sys {
 
         void Start();
 
-        void Kill();
+        void Kill(int timeoutMs = 3000);
 
         CoreProcess(const QString &core_path, const QString &socketName, bool debugMode);
 

--- a/include/sys/Process.hpp
+++ b/include/sys/Process.hpp
@@ -24,6 +24,12 @@ namespace Configs_sys {
 
         void Restart();
 
+        void SetUsePkexec(bool enable);
+
+        bool IsUsingPkexec() const;
+
+        void MarkCoreReportedStarted();
+
         int start_profile_when_core_is_up = -1;
 
     private:
@@ -32,6 +38,10 @@ namespace Configs_sys {
         bool show_stderr = false;
         bool failed_to_start = false;
         bool restarting = false;
+        bool use_pkexec = false;
+        bool last_start_used_pkexec = false;
+        bool core_reported_started = false;
+        bool root_start_failed_reported = false;
 
         QElapsedTimer coreRestartTimer;
 

--- a/include/ui/mainwindow.h
+++ b/include/ui/mainwindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMainWindow>
+#include <functional>
 #include <include/global/HTTPRequestHelper.hpp>
 #ifndef Q_MOC_RUN
 #include <core/server/gen/libcore.pb.h>
@@ -77,13 +78,17 @@ public:
 
     void set_spmode_vpn(bool enable, bool save = true);
 
-    bool get_elevated_permissions(int reason = 3);
+    bool get_elevated_permissions(int reason = 3, const std::function<void(bool)> &callback = {});
 
     void start_select_mode(QObject *context, const std::function<void(int)> &callback);
 
     void RegisterHotkey(bool unregister);
 
     bool StopVPNProcess();
+
+    void restart_core_for_tun_enable(bool usePkexec);
+
+    void disable_tun_after_root_start_failure();
 
     void UpdateConnectionList(const QMap<QString, Stats::ConnectionMetadata>& toUpdate, const QMap<QString, Stats::ConnectionMetadata>& toAdd);
 

--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -2656,6 +2656,46 @@ https://matsuridayo.github.io/n-configuration/#vpn-tun</translation>
         <translation>Пользователь решил не запрашивать привилегии, некоторые функции могут не работать</translation>
     </message>
     <message>
+        <source>Core root privileges granted for %1</source>
+        <translation>Права root выданы ядру %1</translation>
+    </message>
+    <message>
+        <source>Core privileges granted, restarting core to enable TUN...</source>
+        <translation>Права ядру выданы, перезапуск ядра для включения TUN...</translation>
+    </message>
+    <message>
+        <source>Re-enabling TUN after core privilege restart...</source>
+        <translation>Повторное включение TUN после перезапуска ядра с правами...</translation>
+    </message>
+    <message>
+        <source>Core still has no root privileges after permission grant; check setuid and filesystem mount options.</source>
+        <translation>У ядра всё ещё нет прав root после выдачи прав; проверьте setuid и параметры монтирования файловой системы.</translation>
+    </message>
+    <message>
+        <source>ThroneCore is on a nosuid mount; using pkexec fallback for TUN.</source>
+        <translation>ThroneCore находится на разделе с nosuid; для TUN используется fallback через pkexec.</translation>
+    </message>
+    <message>
+        <source>setuid did not grant root, but mount is not nosuid; leaving pkexec fallback disabled.</source>
+        <translation>setuid не дал права root, но раздел не nosuid; fallback через pkexec не включён.</translation>
+    </message>
+    <message>
+        <source>ThroneCore started through pkexec but still has no root privileges; disabling TUN.</source>
+        <translation>ThroneCore запущен через pkexec, но всё ещё без прав root; TUN отключён.</translation>
+    </message>
+    <message>
+        <source>Root core start failed, disabling TUN and restarting the core without pkexec.</source>
+        <translation>Запуск ядра с правами root не удался, TUN отключён, ядро перезапускается без pkexec.</translation>
+    </message>
+    <message>
+        <source>Root core start was cancelled or failed; TUN was not enabled.</source>
+        <translation>Запуск ядра с правами root отменён или завершился ошибкой; TUN не включён.</translation>
+    </message>
+    <message>
+        <source>TUN is enabled, but generated sing-box config has no tun inbound.</source>
+        <translation>TUN включён, но в сгенерированной конфигурации sing-box нет tun inbound.</translation>
+    </message>
+    <message>
         <source>Unable to capture screen</source>
         <translation>Невозможно захватить экран</translation>
     </message>

--- a/src/api/RPC.cpp
+++ b/src/api/RPC.cpp
@@ -247,6 +247,22 @@ namespace API {
         }
     }
 
+    QString Client::Shutdown(bool *rpcOK) {
+        libcore::EmptyReq request;
+        libcore::ErrorResp reply;
+        std::vector<uint8_t> resp;
+        auto status = channel->Call("Shutdown", spb::pb::serialize<std::string>(request), resp, 3000);
+
+        if (status == CALL_OK) {
+            reply = spb::pb::deserialize<libcore::ErrorResp>(resp);
+            *rpcOK = true;
+            return QString::fromStdString(reply.error.value());
+        } else {
+            NOT_OK
+            return "";
+        }
+    }
+
     libcore::QueryStatsResp Client::QueryStats() {
         libcore::EmptyReq request;
         libcore::QueryStatsResp reply;

--- a/src/sys/Process.cpp
+++ b/src/sys/Process.cpp
@@ -13,9 +13,12 @@ namespace Configs_sys {
     CoreProcess::~CoreProcess() {
     }
 
-    void CoreProcess::Kill() {
+    void CoreProcess::Kill(int timeoutMs) {
+        if (state() == NotRunning) return;
         kill();
-        waitForFinished();
+        if (!waitForFinished(timeoutMs)) {
+            MW_show_log("[Warn] " + QObject::tr("Core process did not exit within %1 ms. Continuing shutdown.").arg(timeoutMs));
+        }
     }
 
     CoreProcess::CoreProcess(const QString &core_path, const QString &socketName, bool debugMode)

--- a/src/sys/Process.cpp
+++ b/src/sys/Process.cpp
@@ -40,6 +40,10 @@ namespace Configs_sys {
             if (error == FailedToStart) {
                 failed_to_start = true;
                 MW_show_log("start core error occurred: " + errorString() + "\n");
+                if (last_start_used_pkexec && !root_start_failed_reported) {
+                    root_start_failed_reported = true;
+                    MW_dialog_message("ExternalProcess", "RootStartFailed");
+                }
             }
         });
         connect(this, &QProcess::stateChanged, this, [&](ProcessState state) {
@@ -49,6 +53,15 @@ namespace Configs_sys {
             }
 
             if (!Configs::dataManager->settingsRepo->prepare_exit && state == NotRunning) {
+                if (last_start_used_pkexec && !core_reported_started) {
+                    failed_to_start = true;
+                    MW_show_log("[Error] " + QObject::tr("Root core start was cancelled or failed; TUN was not enabled."));
+                    if (!root_start_failed_reported) {
+                        root_start_failed_reported = true;
+                        MW_dialog_message("ExternalProcess", "RootStartFailed");
+                    }
+                    return;
+                }
                 if (failed_to_start) return; // no retry
                 if (restarting) return;
 
@@ -78,11 +91,28 @@ namespace Configs_sys {
     void CoreProcess::Start() {
         if (started) return;
         started = true;
+        failed_to_start = false;
+        core_reported_started = false;
+        root_start_failed_reported = false;
+        last_start_used_pkexec = false;
 
         auto env = QProcessEnvironment::systemEnvironment();
         env.insert("THRONE_CORE_SOCKET", m_socketName);
         if (m_debugMode) env.insert("THRONE_CORE_DEBUG", "1");
         setProcessEnvironment(env);
+#ifdef Q_OS_LINUX
+        if (use_pkexec) {
+            QStringList pkexecArgs;
+            pkexecArgs << "env";
+            pkexecArgs << "THRONE_CORE_SOCKET=" + m_socketName;
+            pkexecArgs << "THRONE_CORE_PKEXEC=1";
+            if (m_debugMode) pkexecArgs << "THRONE_CORE_DEBUG=1";
+            pkexecArgs << program;
+            last_start_used_pkexec = true;
+            start("pkexec", pkexecArgs);
+            return;
+        }
+#endif
         start(program, {});
     }
 
@@ -93,6 +123,18 @@ namespace Configs_sys {
         started = false;
         Start();
         restarting = false;
+    }
+
+    void CoreProcess::SetUsePkexec(bool enable) {
+        use_pkexec = enable;
+    }
+
+    bool CoreProcess::IsUsingPkexec() const {
+        return use_pkexec;
+    }
+
+    void CoreProcess::MarkCoreReportedStarted() {
+        core_reported_started = true;
     }
 
 } // namespace Configs_sys

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -5,6 +5,7 @@
 #include <ranges>
 
 #include "include/configs/sub/GroupUpdater.hpp"
+#include "include/api/RPC.h"
 #include "include/sys/Process.hpp"
 #include "include/sys/AutoRun.hpp"
 
@@ -1491,6 +1492,12 @@ void MainWindow::prepare_exit()
     //
     Configs::dataManager->settingsRepo->noSave = true; // don't change Configs::dataManager->settingsRepo after this line
     profile_stop(false, true);
+
+    if (API::defaultClient != nullptr && Configs::dataManager->settingsRepo->core_running) {
+        bool rpcOK = false;
+        const auto error = API::defaultClient->Shutdown(&rpcOK);
+        if (rpcOK && !error.isEmpty()) MW_show_log("[Warn] " + tr("Core shutdown returned error: %1").arg(error));
+    }
 
     runOnThread([=, this]()
     {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -40,7 +40,10 @@
 #include "include/sys/linux/LinuxCap.h"
 #include <QDBusInterface>
 #include <QDBusReply>
+#include <QStandardPaths>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
 #endif
 #ifdef Q_OS_MACOS
 #include <sys/socket.h>
@@ -63,6 +66,7 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #include <QStyleHints>
@@ -78,6 +82,55 @@
 
 #include "include/sys/macos/MacOS.h"
 
+#ifdef Q_OS_LINUX
+namespace {
+    QString LinuxProcessExePath(qint64 pid) {
+        QFileInfo exeInfo(QString("/proc/%1/exe").arg(pid));
+        const auto path = exeInfo.symLinkTarget();
+        if (path.endsWith(" (deleted)")) return path.left(path.size() - 10);
+        return path;
+    }
+
+    bool LinuxPathHasNoSuid(const QString &path) {
+        const auto encodedPath = QFile::encodeName(path);
+        struct statvfs fsInfo {};
+        if (statvfs(encodedPath.constData(), &fsInfo) != 0) return false;
+        return (fsInfo.f_flag & ST_NOSUID) != 0;
+    }
+
+    QString LinuxCorePrivilegeDiagnostics() {
+        const auto corePath = Configs::FindCoreRealPath();
+        QStringList parts;
+
+        const auto encodedPath = QFile::encodeName(corePath);
+        struct stat fileInfo {};
+        if (stat(encodedPath.constData(), &fileInfo) == 0) {
+            parts << QString("mode=%1 uid=%2 gid=%3")
+                         .arg(QString::number(fileInfo.st_mode & 07777, 8))
+                         .arg(fileInfo.st_uid)
+                         .arg(fileInfo.st_gid);
+        } else {
+            parts << QString("stat failed for %1").arg(corePath);
+        }
+
+        const auto findmnt = QStandardPaths::findExecutable("findmnt");
+        if (!findmnt.isEmpty()) {
+            QProcess process;
+            process.setProgram(findmnt);
+            process.setArguments({"-no", "TARGET,OPTIONS", "-T", corePath});
+            process.setProcessChannelMode(QProcess::SeparateChannels);
+            process.start();
+            if (process.waitForFinished(1000) && process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0) {
+                const auto mountInfo = QString::fromLocal8Bit(process.readAllStandardOutput()).simplified();
+                if (!mountInfo.isEmpty()) parts << QString("mount=%1").arg(mountInfo);
+            }
+        }
+
+        return parts.join("; ");
+    }
+}
+#endif
+
 void UI_InitMainWindow() {
     mainwindow = new MainWindow;
 }
@@ -91,7 +144,11 @@ bool MainWindow::verify_core_pid(QLocalSocket *socket) {
     struct ucred cred = {};
     socklen_t credLen = sizeof(cred);
     if (getsockopt(static_cast<int>(socket->socketDescriptor()), SOL_SOCKET, SO_PEERCRED, &cred, &credLen) == 0) {
-        return static_cast<qint64>(cred.pid) == expectedPid;
+        if (static_cast<qint64>(cred.pid) == expectedPid) return true;
+        if (core_process->IsUsingPkexec()) {
+            return QFileInfo(LinuxProcessExePath(cred.pid)).canonicalFilePath() ==
+                   QFileInfo(Configs::FindCoreRealPath()).canonicalFilePath();
+        }
     }
     return false;
 #elif defined(Q_OS_MACOS)
@@ -230,7 +287,10 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         }
         setup_rpc(socket);
         auto profileId = core_process ? core_process->start_profile_when_core_is_up : -1;
-        if (core_process) core_process->start_profile_when_core_is_up = -1;
+        if (core_process) {
+            core_process->MarkCoreReportedStarted();
+            core_process->start_profile_when_core_is_up = -1;
+        }
         Configs::dataManager->settingsRepo->core_running = true;
         MW_dialog_message("ExternalProcess", "CoreStarted," + Int2String(profileId));
     });
@@ -1279,18 +1339,53 @@ void MainWindow::dialog_message_impl(const QString &sender, const QString &info)
     } else if (sender == "ExternalProcess") {
         if (info == "Crashed") {
             profile_stop();
+        } else if (info == "RootStartFailed") {
+            disable_tun_after_root_start_failure();
         } else if (info.startsWith("CoreStarted")) {
-            Configs::IsAdmin(true);
+            const bool corePrivileged = Configs::IsAdmin(true);
             if (Configs::dataManager->settingsRepo->system_proxy_enabled) {
                 set_spmode_system_proxy(true, false);
             }
+            bool tunRestoreStartedProfile = false;
             if (Configs::dataManager->settingsRepo->tun_mode_enabled || Configs::dataManager->settingsRepo->flag_restart_tun_on) {
-                set_spmode_vpn(true, false);
+                const bool afterPrivilegeRestart = Configs::dataManager->settingsRepo->flag_restart_tun_on;
+                if (afterPrivilegeRestart) {
+                    MW_show_log(tr("Re-enabling TUN after core privilege restart..."));
+                }
+                if (afterPrivilegeRestart && !corePrivileged) {
+#ifdef Q_OS_LINUX
+                    MW_show_log(tr("Core still has no root privileges after permission grant; check setuid and filesystem mount options."));
+                    MW_show_log(QString("ThroneCore privilege diagnostics: %1").arg(LinuxCorePrivilegeDiagnostics()));
+                    if (!core_process->IsUsingPkexec()) {
+                        if (LinuxPathHasNoSuid(Configs::FindCoreRealPath())) {
+                            MW_show_log(tr("ThroneCore is on a nosuid mount; using pkexec fallback for TUN."));
+                            Configs::dataManager->settingsRepo->flag_restart_tun_on = true;
+                            Configs::dataManager->settingsRepo->Save();
+                            restart_core_for_tun_enable(true);
+                            refresh_status();
+                            return;
+                        }
+                        MW_show_log(tr("setuid did not grant root, but mount is not nosuid; leaving pkexec fallback disabled."));
+                        disable_tun_after_root_start_failure();
+                        return;
+                    }
+                    MW_show_log(tr("ThroneCore started through pkexec but still has no root privileges; disabling TUN."));
+                    disable_tun_after_root_start_failure();
+#else
+                    MW_show_log(tr("Core still has no root privileges after permission grant; check setuid and filesystem mount options."));
+                    refresh_status();
+#endif
+                    return;
+                } else {
+                    Configs::dataManager->settingsRepo->flag_restart_tun_on = false;
+                    tunRestoreStartedProfile = !Configs::dataManager->settingsRepo->spmode_vpn && Configs::dataManager->settingsRepo->started_id >= 0;
+                    set_spmode_vpn(true, false);
+                }
             }
             if (Configs::dataManager->settingsRepo->flag_dns_set) {
                 set_system_dns(true);
             }
-            if (auto id = info.split(",")[1].toInt(); id >= 0)
+            if (auto id = info.split(",")[1].toInt(); id >= 0 && !tunRestoreStartedProfile)
             {
                 profile_start(id);
             }
@@ -1454,7 +1549,7 @@ void MainWindow::toggle_system_proxy() {
     }
 }
 
-bool MainWindow::get_elevated_permissions(int reason) {
+bool MainWindow::get_elevated_permissions(int reason, const std::function<void(bool)> &callback) {
     if (Configs::dataManager->settingsRepo->disable_privilege_req)
     {
         MW_show_log(tr("User opted for no privilege req, some features may not work"));
@@ -1464,26 +1559,42 @@ bool MainWindow::get_elevated_permissions(int reason) {
 #ifdef Q_OS_LINUX
     if (!Linux_HavePkexec()) {
         MessageBoxWarning(software_name, "Please install \"pkexec\" first.");
+        if (callback) callback(false);
         return false;
     }
     auto n = QMessageBox::warning(GetMessageBoxParent(), software_name, tr("Please give the core root privileges"), QMessageBox::Yes | QMessageBox::No);
     if (n == QMessageBox::Yes) {
         runOnNewThread([=,this]
         {
-            auto chownArgs = QString("root:root " + Configs::FindCoreRealPath());
+            auto corePath = Configs::FindCoreRealPath();
+            auto finish = [=, this](bool granted) {
+                if (callback) {
+                    callback(granted);
+                } else if (granted) {
+                    StopVPNProcess();
+                }
+            };
+
+            auto chownArgs = QString("root:root " + corePath);
             auto ret = Linux_Run_Command("chown", chownArgs);
             if (ret != 0) {
                 MW_show_log(QString("Failed to run chown %1 code is %2").arg(chownArgs).arg(ret));
+                finish(false);
+                return;
             }
-            auto chmodArgs = QString("u+s " + Configs::FindCoreRealPath());
+            auto chmodArgs = QString("u+s " + corePath);
             ret = Linux_Run_Command("chmod", chmodArgs);
             if (ret == 0) {
-                StopVPNProcess();
+                MW_show_log(tr("Core root privileges granted for %1").arg(corePath));
+                finish(true);
             } else {
                 MW_show_log(QString("Failed to run chmod %1").arg(chmodArgs));
+                finish(false);
             }
         });
         return false;
+    } else if (callback) {
+        callback(false);
     }
 #endif
 #ifdef Q_OS_WIN
@@ -1491,6 +1602,8 @@ bool MainWindow::get_elevated_permissions(int reason) {
     if (n == QMessageBox::Yes) {
         this->exit_reason = reason;
         on_menu_exit_triggered();
+    } else if (callback) {
+        callback(false);
     }
 #endif
 
@@ -1507,11 +1620,15 @@ bool MainWindow::get_elevated_permissions(int reason) {
         auto ret = Mac_Run_Command(Command);
         if (ret == 0) {
             MessageBoxInfo(tr("Requesting permission"), tr("Please Enter your password in the opened terminal, then try again"));
+            if (callback) callback(false);
             return false;
         } else {
             MW_show_log(QString("Failed to run %1 with %2").arg(Command).arg(ret));
+            if (callback) callback(false);
             return false;
         }
+    } else if (callback) {
+        callback(false);
     }
 #endif
     return false;
@@ -1556,7 +1673,34 @@ void MainWindow::set_spmode_vpn(bool enable, bool save) {
     if (enable) {
         bool requestPermission = !Configs::IsAdmin();
         if (requestPermission) {
-            if (!get_elevated_permissions()) {
+#ifdef Q_OS_LINUX
+            if (LinuxPathHasNoSuid(Configs::FindCoreRealPath())) {
+                if (save) {
+                    Configs::dataManager->settingsRepo->tun_mode_enabled = true;
+                }
+                Configs::dataManager->settingsRepo->flag_restart_tun_on = true;
+                Configs::dataManager->settingsRepo->Save();
+                MW_show_log(tr("ThroneCore is on a nosuid mount; using pkexec fallback for TUN."));
+                restart_core_for_tun_enable(true);
+                refresh_status();
+                return;
+            }
+#endif
+            auto enableTunAfterPrivilege = [=, this](bool granted) {
+                if (!granted) {
+                    runOnUiThread([=, this] { refresh_status(); });
+                    return;
+                }
+
+                if (save) {
+                    Configs::dataManager->settingsRepo->tun_mode_enabled = true;
+                    Configs::dataManager->settingsRepo->Save();
+                }
+                Configs::dataManager->settingsRepo->flag_restart_tun_on = true;
+                MW_show_log(tr("Core privileges granted, restarting core to enable TUN..."));
+                restart_core_for_tun_enable(false);
+            };
+            if (!get_elevated_permissions(3, enableTunAfterPrivilege)) {
                 refresh_status();
                 return;
             }
@@ -2994,6 +3138,42 @@ bool MainWindow::StopVPNProcess() {
     }, DS_cores, true);
 
     return true;
+}
+
+void MainWindow::restart_core_for_tun_enable(bool usePkexec) {
+    if (QThread::currentThread() != qApp->thread()) {
+        runOnUiThread([=, this] { restart_core_for_tun_enable(usePkexec); });
+        return;
+    }
+
+    const auto profileId = Configs::dataManager->settingsRepo->started_id;
+    if (running != nullptr) {
+        profile_stop(true, true);
+    }
+
+    runOnThread([=, this]
+    {
+        core_process->SetUsePkexec(usePkexec);
+        core_process->start_profile_when_core_is_up = profileId;
+        core_process->Restart();
+    }, DS_cores);
+}
+
+void MainWindow::disable_tun_after_root_start_failure() {
+    Configs::dataManager->settingsRepo->flag_restart_tun_on = false;
+    Configs::dataManager->settingsRepo->spmode_vpn = false;
+    Configs::dataManager->settingsRepo->tun_mode_enabled = false;
+    Configs::dataManager->settingsRepo->Save();
+    MW_show_log(tr("Root core start failed, disabling TUN and restarting the core without pkexec."));
+
+    runOnThread([=, this]
+    {
+        core_process->SetUsePkexec(false);
+        core_process->start_profile_when_core_is_up = -1;
+        core_process->Restart();
+    }, DS_cores);
+
+    refresh_status();
 }
 
 bool isNewer(QString assetName) {

--- a/src/ui/mainwindow_rpc.cpp
+++ b/src/ui/mainwindow_rpc.cpp
@@ -9,6 +9,7 @@
 #include <QPushButton>
 #include <QDesktopServices>
 #include <QMessageBox>
+#include <QJsonArray>
 #include <QJsonDocument>
 
 #include "include/configs/generate.h"
@@ -707,6 +708,19 @@ void MainWindow::profile_start(int _id) {
     if (!result->error.isEmpty()) {
         MessageBoxWarning(tr("BuildConfig return error"), result->error);
         return;
+    }
+    if (Configs::dataManager->settingsRepo->spmode_vpn) {
+        bool hasTunInbound = false;
+        for (const auto inboundValue: result->coreConfig["inbounds"].toArray()) {
+            const auto inbound = inboundValue.toObject();
+            if (inbound["tag"].toString() == "tun-in" || inbound["type"].toString() == "tun") {
+                hasTunInbound = true;
+                break;
+            }
+        }
+        if (!hasTunInbound) {
+            MW_show_log("[Warn] " + tr("TUN is enabled, but generated sing-box config has no tun inbound."));
+        }
     }
 
     auto profile_start_stage2 = [=, this] {


### PR DESCRIPTION
This PR improves Linux TUN startup handling and diagnostics.

The main goal is to make TUN startup failures easier to detect and explain. For example, if Throne is unpacked on a `nosuid` mount, the usual setuid-based privilege flow cannot work even if `chown` and `chmod u+s` appear to succeed. In that case Throne now detects the condition and uses a `pkexec` fallback for `ThroneCore` instead of leaving the user with a TUN mode that simply does not start.

This may also help diagnose or resolve some existing Linux TUN startup reports where privilege setup fails, appears to succeed, or ends with generic core-not-running / operation-not-permitted errors.


## Why
Linux TUN requires elevated privileges. Throne normally grants them to `ThroneCore` with `chown root:root` and `chmod u+s`, then restarts the core.

This flow depends on the filesystem honoring setuid. On mounts with `nosuid`, setuid is ignored by the kernel. The permission commands may still complete successfully, but the restarted core will not run with root privileges, so TUN cannot be created.

Without explicit detection this failure is hard to understand: the user sees Polkit prompts and a restart, but TUN still does not work. This PR makes that case visible in logs and switches to a root-start fallback only when setuid is known not to work.

## Changes
- detect whether the `ThroneCore` path is on a `nosuid` mount
- use `pkexec` fallback for `ThroneCore` when setuid cannot work because of `nosuid`
- keep the existing setuid flow on normal mounts
- add diagnostics for failed privilege startup, including file mode/owner and mount options
- fix exit hangs with root `ThroneCore` by adding RPC shutdown and bounding the final process wait
