### PR TITLE
Fix DNS final routing and temporary port reservation

### DIFF
--- a/include/database/SettingsRepo.h
+++ b/include/database/SettingsRepo.h
@@ -136,7 +136,7 @@ namespace Configs {
         bool enable_dns_routing = true;
         bool use_dns_object = false;
         QString dns_object = "";
-        QString dns_final_out = "proxy";
+        QString dns_final_out = "remote";
         QString resolve_domain_strategy = "";
         QString default_domain_strategy = "";
         int sniffing_mode = SniffingMode::FOR_ROUTING;

--- a/include/ui/group/dialog_edit_group.h
+++ b/include/ui/group/dialog_edit_group.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <QDialog>
+#include <QHash>
 #include "ui_dialog_edit_group.h"
 #include "include/database/entities/Group.h"
+
+class QComboBox;
 
 QT_BEGIN_NAMESPACE
 namespace Ui {
@@ -30,6 +33,10 @@ private:
     struct {
         int landing_proxy;
     } LANDING;
+
+    QHash<QString, int> proxyNameToId;
+
+    int resolve_proxy_selection(QComboBox *combo, int fallback) const;
 
 private slots:
 

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -885,6 +885,23 @@ namespace Configs {
                 return;
             }
             object["tag"] = tag;
+            if (bridgeConfig.loopbackProtect) {
+                auto streamSettings = object["streamSettings"].toObject();
+                const auto network = streamSettings["network"].toString();
+                if (network == "xhttp" || network == "splithttp") {
+                    auto xhttpSettings = streamSettings["xhttpSettings"].toObject();
+                    if (xhttpSettings.isEmpty()) xhttpSettings = streamSettings["splithttpSettings"].toObject();
+                    auto extraSettings = xhttpSettings["extra"].toObject();
+                    if (extraSettings.contains("downloadSettings")) {
+                        // XHTTP downloadSettings gets its own stream config;
+                        // penetrate makes Xray copy this sockopt there too.
+                        auto sockopt = streamSettings["sockopt"].toObject();
+                        sockopt["penetrate"] = true;
+                        streamSettings["sockopt"] = sockopt;
+                        object["streamSettings"] = streamSettings;
+                    }
+                }
+            }
             // A bridge always requires chaining the preceding hop into it,
             // even when `link` is false (single-hop route groups). nextTag
             // already encodes whether anything follows, so honoring it

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -1107,8 +1107,8 @@ namespace Configs {
 
         // Also add the needed socks inbound bridges. Loopback-protect bridges
         // have no sing-box ingress to pair with (their inbound routes straight
-        // to `direct`), so the singIngressTags index only advances for normal
-        // xray->sing bridges.
+        // to the hidden `xray-direct`), so the singIngressTags index only
+        // advances for normal xray->sing bridges.
         int loopbackBridgeCount = 0;
         for (const auto& b : ctx->xrayToSingBridges) if (b.loopbackProtect) loopbackBridgeCount++;
         if (ctx->xrayToSingBridges.size() - loopbackBridgeCount != ctx->singIngressTags.size()) {
@@ -1139,6 +1139,13 @@ namespace Configs {
             inboundArr.append(socksBridge);
         }
         ctx->buildConfigResult->coreConfig["inbounds"] = inboundArr;
+
+        if (loopbackBridgeCount > 0) {
+            ctx->outbounds.append(QJsonObject{
+                {"type", "direct"},
+                {"tag", "xray-direct"}
+            });
+        }
 
         // Add the direct outbound
         ctx->outbounds.append(QJsonObject{
@@ -1254,8 +1261,9 @@ namespace Configs {
         }
 
         // map ingress socks inbounds to their corresponding outbounds.
-        // Loopback-protect bridges route to `direct` (auto_detect_interface
-        // bypasses TUN); normal bridges route to the paired sing-box ingress.
+        // Loopback-protect bridges route to hidden `xray-direct`
+        // (auto_detect_interface bypasses TUN); normal bridges route to the
+        // paired sing-box ingress.
         int routeLoopbackBridgeCount = 0;
         for (const auto& b : ctx->xrayToSingBridges) if (b.loopbackProtect) routeLoopbackBridgeCount++;
         if (ctx->xrayToSingBridges.size() - routeLoopbackBridgeCount != ctx->singIngressTags.size()) {
@@ -1268,7 +1276,7 @@ namespace Configs {
             QString inboundTag, outboundTag;
             if (bridgeConf.loopbackProtect) {
                 inboundTag = "bridge-loopback-" + Int2String(bridgeConf.port);
-                outboundTag = "direct";
+                outboundTag = "xray-direct";
             } else {
                 inboundTag = "bridge-" + ctx->singIngressTags[routeSingIngressIdx];
                 outboundTag = ctx->singIngressTags[routeSingIngressIdx];

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -590,12 +590,13 @@ namespace Configs {
                 };
         }
 
+        const bool useDirectFinalDNS = dataManager->settingsRepo->dns_final_out == "direct";
+
         // Symmetric to the direct carve-out above: when the final DNS is direct,
         // proxy-routed sites would otherwise resolve via direct DNS, so route
-        // them to remote DNS (when final is remote they reach it via the final
-        // rule, and the direct carve-out already runs first to keep server
-        // hostnames on direct DNS).
-        if (dnsDeps->needProxyDnsRules && dataManager->settingsRepo->dns_final_out != "remote") {
+        // them to remote DNS. "proxy" and "remote" both use remote DNS; only
+        // explicit "direct" should fall back to local DNS.
+        if (dnsDeps->needProxyDnsRules && useDirectFinalDNS) {
             rules += QJsonObject{
                     {"rule_set", dnsDeps->proxyRuleSets},
                     {"domain", dnsDeps->proxyDomains},
@@ -609,8 +610,8 @@ namespace Configs {
         }
 
         // final rule: proxy
-        auto finalStrategy = dataManager->settingsRepo->dns_final_out == "remote" ? dataManager->settingsRepo->remote_dns_strategy : dataManager->settingsRepo->direct_dns_strategy;
-        auto finalDNS = dataManager->settingsRepo->dns_final_out == "remote" ? "dns-remote" : "dns-direct";
+        auto finalStrategy = useDirectFinalDNS ? dataManager->settingsRepo->direct_dns_strategy : dataManager->settingsRepo->remote_dns_strategy;
+        auto finalDNS = useDirectFinalDNS ? "dns-direct" : "dns-remote";
         rules += QJsonObject{
             {"strategy", finalStrategy},
             {"action", "route"},

--- a/src/global/Utils.cpp
+++ b/src/global/Utils.cpp
@@ -205,12 +205,15 @@ QList<int> MkManyPorts(int num) {
     QList<int> res;
     QList<QTcpServer*> servers;
     for (int i=0;i<num;i++) {
-        QTcpServer s;
-        s.listen();
-        servers.append(&s);
-        res.append(s.serverPort());
+        auto server = new QTcpServer();
+        server->listen();
+        servers.append(server);
+        res.append(server->serverPort());
     }
-    for (const auto s: servers) s->close();
+    for (const auto s: servers) {
+        s->close();
+        delete s;
+    }
     servers.clear();
     return res;
 }

--- a/src/ui/group/dialog_edit_group.cpp
+++ b/src/ui/group/dialog_edit_group.cpp
@@ -66,6 +66,8 @@ DialogEditGroup::DialogEditGroup(const std::shared_ptr<Configs::Group> &ent, QWi
         }
     }
     QStringList proxyNameList;
+    proxyNameToId.clear();
+    proxyNameToId.insert("None", -1);
     ui->front_proxy->setMaxCount(200);
     ui->landing_proxy->setMaxCount(200);
     ui->front_proxy->blockSignals(true);
@@ -78,6 +80,9 @@ DialogEditGroup::DialogEditGroup(const std::shared_ptr<Configs::Group> &ent, QWi
     int comboCount = 1; // "None" already added
     for (const auto&[id, name] : proxyList) {
         proxyNameList.append(name);
+        if (!proxyNameToId.contains(name)) {
+            proxyNameToId.insert(name, id);
+        }
         if (comboCount < comboCap) {
             ui->front_proxy->addItem(name, QVariant(id));
             ui->landing_proxy->addItem(name, QVariant(id));
@@ -112,7 +117,13 @@ DialogEditGroup::DialogEditGroup(const std::shared_ptr<Configs::Group> &ent, QWi
             debounce->start();
         });
         connect(completer, qOverload<const QString&>(&QCompleter::activated),
-                         lineEdit, [lineEdit](const QString& text) { lineEdit->setText(text); });
+                         lineEdit, [combo, lineEdit](const QString& text) {
+            lineEdit->setText(text);
+            const int index = combo->findText(text, Qt::MatchExactly);
+            if (index >= 0) {
+                combo->setCurrentIndex(index);
+            }
+        });
     };
 
     ui->front_proxy->setEditable(true);
@@ -171,6 +182,25 @@ DialogEditGroup::~DialogEditGroup() {
     delete ui;
 }
 
+int DialogEditGroup::resolve_proxy_selection(QComboBox *combo, int fallback) const {
+    const QString text = combo->currentText().trimmed();
+    if (text.isEmpty() || text == "None") {
+        return -1;
+    }
+
+    const int index = combo->findText(text, Qt::MatchExactly);
+    if (index >= 0) {
+        return combo->itemData(index).value<int>();
+    }
+
+    auto it = proxyNameToId.constFind(text);
+    if (it != proxyNameToId.constEnd()) {
+        return it.value();
+    }
+
+    return fallback;
+}
+
 void DialogEditGroup::accept() {
     if (ent->id >= 0) { // already a group
         if (!ent->url.isEmpty() && ui->url->text().isEmpty()) {
@@ -182,8 +212,8 @@ void DialogEditGroup::accept() {
     ent->auto_clear_unavailable = ui->auto_clear_unavailable->isChecked();
     ent->url = ui->url->text();
     ent->skip_auto_update = ui->skip_auto_update->isChecked();
-    ent->front_proxy_id = CACHE.front_proxy;
-    ent->landing_proxy_id = LANDING.landing_proxy;
+    ent->front_proxy_id = resolve_proxy_selection(ui->front_proxy, CACHE.front_proxy);
+    ent->landing_proxy_id = resolve_proxy_selection(ui->landing_proxy, LANDING.landing_proxy);
     QDialog::accept();
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a few small regressions that showed up around DNS routing, Xray/TUN, and local helper ports:

- Treat `dns_final_out=proxy` as remote DNS during config generation. The UI now writes `remote`, but existing databases can still contain `proxy`, and that value should not fall through to `dns-direct`.
- Keep temporary `MkManyPorts()` listeners alive until every requested port has been selected, so generated bridge ports are reserved as a group.
- Fix Xray/TUN loopback handling for XHTTP profiles, including the XHTTP download side.
- Fix Front/Landing proxy selection in the group editor when the editable combo box is cleared or completed manually.

## Why

After [ee1988db](https://github.com/throneproj/Throne/commit/ee1988dbac0f45ade9de26ae7b9e331d753279b6), final DNS selection checked for `remote` explicitly. A saved value of `proxy` therefore behaved like `direct`, which could leak DNS queries through local resolvers.

`MkManyPorts()` also released each port immediately because the `QTcpServer` lived only inside the loop iteration. Keeping the listeners alive reserves the selected ports as a group.

The Xray/TUN fix covers a loopback case where Xray traffic could re-enter TUN instead of leaving through the direct path. XHTTP made this easier to reproduce because its upload and download sides are handled separately.

## Testing

Tested locally on Windows 11:

- XHTTP Reality profile in TUN mode, including repeated stop/start;
- normal proxy mode;
- DNS leak check after the DNS routing fix;
- Front/Landing proxy selection and clearing in the group editor;
- local Windows build.

## Fixed Issues

Fixes #1366  
Fixes #1457  
Fixes #1477  
Fixes #1496  
Fixes #1494  