### PR TITLE
security: fix command injection and harden update channel, build supply chain, and HTML output

### DIFF
--- a/include/global/HTTPRequestHelper.hpp
+++ b/include/global/HTTPRequestHelper.hpp
@@ -26,11 +26,15 @@ namespace Configs_network {
         ;
 
     public:
-        static HTTPResponse HttpGet(const QString &url, bool sendHwid = false, bool useProxy = false);
+        // forceSecure overrides the global net_insecure setting and always
+        // enforces TLS certificate verification. Used for trust-critical
+        // channels (e.g. the auto-update download) that must never be served
+        // over an unverified connection.
+        static HTTPResponse HttpGet(const QString &url, bool sendHwid = false, bool useProxy = false, bool forceSecure = false);
 
         static QString GetHeader(const QList<QPair<QByteArray, QByteArray>> &header, const QString &name);
 
-        static QString DownloadAsset(const QString &url, const QString &fileName);
+        static QString DownloadAsset(const QString &url, const QString &fileName, bool forceSecure = false);
     };
 } // namespace Configs_network
 

--- a/include/sys/linux/LinuxCap.h
+++ b/include/sys/linux/LinuxCap.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <QString>
+#include <QStringList>
 
 bool Linux_HavePkexec();
 
 QString Linux_FindCapProgsExec(const QString &name);
 
-int Linux_Run_Command(const QString &commandName, const QString &args);
+int Linux_Run_Command(const QString &commandName, const QStringList &args);

--- a/include/sys/macos/MacOS.h
+++ b/include/sys/macos/MacOS.h
@@ -2,4 +2,4 @@
 
 #include <QString>
 
-int Mac_Run_Command(QString command);
+int Mac_Run_Command(const QString &corePath);

--- a/script/build_go.sh
+++ b/script/build_go.sh
@@ -8,9 +8,46 @@ mkdir -p $DEST
 
 [[ "$GOOS" =~ legacy$ ]] && IS_LEGACY=true && GOCMD="$PWD/golang.org/go/bin/go" && GOOS="${GOOS%legacy}" || { IS_LEGACY=false; GOCMD="go"; }
 
+# --- Supply-chain integrity for downloaded prebuilt binaries ---------------
+# Every binary fetched from a release page must match a sha256 pinned in
+# script/deps.sha256 (format: "<remote-filename>  <sha256>"). This fails the
+# build closed if an artifact was tampered with, replaced, or silently bumped.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPS_SHA_FILE="$SCRIPT_DIR/deps.sha256"
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+# verify_sha256 <downloaded-file> <pin-key>
+verify_sha256() {
+    local file="$1" key="$2" expected actual
+    expected=$(awk -v k="$key" '$1==k {print $2; exit}' "$DEPS_SHA_FILE" 2>/dev/null)
+    if [[ -z "$expected" || "$expected" == "PUT_REAL_SHA256_HERE" ]]; then
+        echo "ERROR: no pinned sha256 for '$key' in $DEPS_SHA_FILE" >&2
+        echo "       download verified hash and add a line: '$key  <sha256>'" >&2
+        echo "       actual sha256 of fetched file: $(sha256_of "$file")" >&2
+        exit 1
+    fi
+    actual=$(sha256_of "$file")
+    if [[ "$actual" != "$expected" ]]; then
+        echo "ERROR: checksum mismatch for '$key'" >&2
+        echo "       expected: $expected" >&2
+        echo "       actual:   $actual" >&2
+        exit 1
+    fi
+    echo "verified $key ($actual)"
+}
+
 if [[ "$GOOS" == "windows" || "$GOOS" == "linux" ]]; then
     FILE=$([[ "$GOOS" == "windows" ]] && echo "updater-windows-x${GOARCH: -2}.exe" || echo "updater-linux-$GOARCH")
-    curl -fLso "$DEST/updater$([[ "$GOOS" == "windows" ]] && echo ".exe")" "https://github.com/throneproj/updater/releases/latest/download/$FILE"
+    UPDATER_OUT="$DEST/updater$([[ "$GOOS" == "windows" ]] && echo ".exe")"
+    curl -fLso "$UPDATER_OUT" "https://github.com/throneproj/updater/releases/latest/download/$FILE"
+    verify_sha256 "$UPDATER_OUT" "$FILE"
     [[ "$GOOS" == "linux" ]] && chmod +x "$DEST/updater"
 fi
 
@@ -20,6 +57,7 @@ case "$GOOS" in
     if ! $IS_LEGACY; then
       TAGS+=",with_purego,with_naive_outbound"
       curl -fLso $DEST/libcronet.dll "https://github.com/SagerNet/cronet-go/releases/latest/download/libcronet-windows-$GOARCH.dll"
+      verify_sha256 "$DEST/libcronet.dll" "libcronet-windows-$GOARCH.dll"
     fi
     ;;
   darwin)

--- a/script/deps.sha256
+++ b/script/deps.sha256
@@ -1,0 +1,18 @@
+# Pinned SHA-256 checksums for prebuilt binaries fetched at build time.
+# Format:  <remote-filename>  <sha256>
+#
+# build_go.sh fails closed if a fetched artifact does not match the hash here.
+# To populate a real value: run the build once, copy the "actual sha256"
+# printed in the ERROR, verify it against the official release, then paste it
+# below (replacing PUT_REAL_SHA256_HERE). Re-pin whenever the upstream
+# release is intentionally bumped.
+#
+# updater (https://github.com/throneproj/updater/releases)
+updater-linux-amd64        PUT_REAL_SHA256_HERE
+updater-linux-arm64        PUT_REAL_SHA256_HERE
+updater-windows-x64.exe    PUT_REAL_SHA256_HERE
+updater-windows-x86.exe    PUT_REAL_SHA256_HERE
+#
+# libcronet (https://github.com/SagerNet/cronet-go/releases)
+libcronet-windows-amd64.dll  PUT_REAL_SHA256_HERE
+libcronet-windows-arm64.dll  PUT_REAL_SHA256_HERE

--- a/src/global/HTTPRequestHelper.cpp
+++ b/src/global/HTTPRequestHelper.cpp
@@ -18,7 +18,7 @@
 
 namespace Configs_network {
 
-    HTTPResponse NetworkRequestHelper::HttpGet(const QString &url, bool sendHwid, bool useProxy) {
+    HTTPResponse NetworkRequestHelper::HttpGet(const QString &url, bool sendHwid, bool useProxy, bool forceSecure) {
         QNetworkRequest request;
         QNetworkAccessManager accessManager;
         accessManager.setTransferTimeout(10000);
@@ -40,7 +40,7 @@ namespace Configs_network {
         // Set attribute
         request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
         request.setHeader(QNetworkRequest::KnownHeaders::UserAgentHeader, Configs::dataManager->settingsRepo->GetUserAgent());
-        if (Configs::dataManager->settingsRepo->net_insecure) {
+        if (Configs::dataManager->settingsRepo->net_insecure && !forceSecure) {
             QSslConfiguration c;
             c.setPeerVerifyMode(QSslSocket::PeerVerifyMode::VerifyNone);
             request.setSslConfiguration(c);
@@ -113,7 +113,7 @@ namespace Configs_network {
         return "";
     }
 
-    QString NetworkRequestHelper::DownloadAsset(const QString &url, const QString &fileName) {
+    QString NetworkRequestHelper::DownloadAsset(const QString &url, const QString &fileName, bool forceSecure) {
         QNetworkRequest request;
         QNetworkAccessManager accessManager;
         request.setUrl(url);
@@ -131,19 +131,19 @@ namespace Configs_network {
             }
             accessManager.setProxy(p);
         }
-        if (Configs::dataManager->settingsRepo->net_insecure) {
+        if (Configs::dataManager->settingsRepo->net_insecure && !forceSecure) {
             QSslConfiguration c;
             c.setPeerVerifyMode(QSslSocket::PeerVerifyMode::VerifyNone);
             request.setSslConfiguration(c);
         }
 
         auto _reply = accessManager.get(request);
-        connect(_reply, &QNetworkReply::sslErrors, _reply, [](const QList<QSslError> &errors) {
+        connect(_reply, &QNetworkReply::sslErrors, _reply, [forceSecure](const QList<QSslError> &errors) {
             QStringList error_str;
             for (const auto &err: errors) {
                 error_str << err.errorString();
             }
-            MW_show_log(QString("SSL Errors: %1 %2").arg(error_str.join(","), Configs::dataManager->settingsRepo->net_insecure ? "(Ignored)" : ""));
+            MW_show_log(QString("SSL Errors: %1 %2").arg(error_str.join(","), (Configs::dataManager->settingsRepo->net_insecure && !forceSecure) ? "(Ignored)" : ""));
         });
         connect(_reply, &QNetworkReply::downloadProgress, _reply, [&](qint64 bytesReceived, qint64 bytesTotal)
         {

--- a/src/sys/linux/LinuxCap.cpp
+++ b/src/sys/linux/LinuxCap.cpp
@@ -4,9 +4,15 @@
 #include <QProcess>
 #include <QStandardPaths>
 
-int Linux_Run_Command(const QString &commandName, const QString &args) {
-    auto command = QString("pkexec %1 %2").arg(Linux_FindCapProgsExec(commandName)).arg(args);
-    return system(command.toStdString().c_str());
+int Linux_Run_Command(const QString &commandName, const QStringList &args) {
+    // Run the privileged command through pkexec with an explicit argument list.
+    // Never build a shell string: passing arguments as a list means metacharacters
+    // in the resolved exec path or in args (e.g. an install dir like ".../x;touch /etc/evil")
+    // are treated as literal data and cannot inject into the root command.
+    QStringList pkexecArgs;
+    pkexecArgs << Linux_FindCapProgsExec(commandName);
+    pkexecArgs << args;
+    return QProcess::execute("pkexec", pkexecArgs);
 }
 
 bool Linux_HavePkexec() {

--- a/src/sys/macos/MacOS.cpp
+++ b/src/sys/macos/MacOS.cpp
@@ -1,9 +1,39 @@
-#include <QFile>
-#include <QFileInfo>
-#include <QString>
-#include <include/global/Utils.hpp>
+#include "include/sys/macos/MacOS.h"
 
-int Mac_Run_Command(QString command) {
-    auto cmd = QString("osascript -e 'tell application \"Terminal\" to activate' -e 'tell application \"Terminal\" to do script \"%1\"' with administrator privileges").arg(command);
-    return system(cmd.toStdString().c_str());
+#include <QProcess>
+#include <QString>
+#include <QStringList>
+
+// Wrap a string in single quotes for a POSIX shell, escaping any embedded
+// single quote with the '\'' idiom. After this the value cannot break out of
+// the shell command, regardless of metacharacters in the path.
+static QString shellSingleQuote(const QString &s) {
+    QString out = s;
+    out.replace("'", "'\\''");
+    return "'" + out + "'";
+}
+
+// Escape a string so it can be safely embedded inside an AppleScript
+// double-quoted string literal.
+static QString appleScriptStringEscape(const QString &s) {
+    QString out = s;
+    out.replace("\\", "\\\\");
+    out.replace("\"", "\\\"");
+    return out;
+}
+
+int Mac_Run_Command(const QString &corePath) {
+    // Build the privileged shell command with the path shell-quoted, then escape
+    // the whole thing for the AppleScript "do script" string. osascript is invoked
+    // through QProcess with each -e as a separate argument, so there is no outer
+    // /bin/sh to inject into either.
+    const QString quotedPath = shellSingleQuote(corePath);
+    const QString shellCommand =
+        QString("sudo chown root:wheel %1 && sudo chmod u+s %1").arg(quotedPath);
+    const QString doScript = appleScriptStringEscape(shellCommand);
+
+    return QProcess::execute("osascript", QStringList{
+        "-e", "tell application \"Terminal\" to activate",
+        "-e", QString("tell application \"Terminal\" to do script \"%1\"").arg(doScript),
+    });
 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -3309,7 +3309,9 @@ void MainWindow::CheckUpdate() {
         return;
     }
 
-    auto resp = NetworkRequestHelper::HttpGet("https://api.github.com/repos/throneproj/Throne/releases");
+    // forceSecure: the update channel must always verify TLS, even if the user
+    // enabled net_insecure for subscriptions. A MITM here leads to code execution.
+    auto resp = NetworkRequestHelper::HttpGet("https://api.github.com/repos/throneproj/Throne/releases", false, false, true);
     if (!resp.error.isEmpty()) {
         runOnUiThread([=,this] {
             MessageBoxWarning(QObject::tr("Update"), QObject::tr("Requesting update error: %1").arg(resp.error + "\n" + resp.data));
@@ -3368,9 +3370,21 @@ void MainWindow::CheckUpdate() {
                 }
                 QString errors;
                 if (!release_download_url.isEmpty()) {
-                    auto res = NetworkRequestHelper::DownloadAsset(release_download_url, "Throne.zip");
-                    if (!res.isEmpty()) {
-                        errors += res;
+                    // Only ever fetch the update payload over verified TLS from a
+                    // trusted GitHub host. Reject anything else to stop a tampered
+                    // API response from redirecting the download to an attacker.
+                    const QUrl dlUrl(release_download_url);
+                    const QString host = dlUrl.host();
+                    const bool trustedHost = host == "github.com"
+                        || host.endsWith(".github.com")
+                        || host.endsWith(".githubusercontent.com");
+                    if (dlUrl.scheme() != "https" || !trustedHost) {
+                        errors += tr("Refused update download from untrusted URL: %1").arg(release_download_url);
+                    } else {
+                        auto res = NetworkRequestHelper::DownloadAsset(release_download_url, "Throne.zip", true);
+                        if (!res.isEmpty()) {
+                            errors += res;
+                        }
                     }
                 }
                 mu_download_update.unlock();

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1629,17 +1629,16 @@ bool MainWindow::get_elevated_permissions(int reason) {
     if (n == QMessageBox::Yes) {
         runOnNewThread([=,this]
         {
-            auto chownArgs = QString("root:root " + Configs::FindCoreRealPath());
-            auto ret = Linux_Run_Command("chown", chownArgs);
+            const auto corePath = Configs::FindCoreRealPath();
+            auto ret = Linux_Run_Command("chown", {"root:root", corePath});
             if (ret != 0) {
-                MW_show_log(QString("Failed to run chown %1 code is %2").arg(chownArgs).arg(ret));
+                MW_show_log(QString("Failed to run chown root:root %1 code is %2").arg(corePath).arg(ret));
             }
-            auto chmodArgs = QString("u+s " + Configs::FindCoreRealPath());
-            ret = Linux_Run_Command("chmod", chmodArgs);
+            ret = Linux_Run_Command("chmod", {"u+s", corePath});
             if (ret == 0) {
                 StopVPNProcess();
             } else {
-                MW_show_log(QString("Failed to run chmod %1").arg(chmodArgs));
+                MW_show_log(QString("Failed to run chmod u+s %1").arg(corePath));
             }
         });
         return false;
@@ -1662,13 +1661,13 @@ bool MainWindow::get_elevated_permissions(int reason) {
     auto n = QMessageBox::warning(GetMessageBoxParent(), software_name, tr("Please give the core root privileges"), QMessageBox::Yes | QMessageBox::No);
     if (n == QMessageBox::Yes)
     {
-        auto Command = QString("sudo chown root:wheel '%1' && sudo chmod u+s '%1'").arg(Configs::FindCoreRealPath());
-        auto ret = Mac_Run_Command(Command);
+        const auto corePath = Configs::FindCoreRealPath();
+        auto ret = Mac_Run_Command(corePath);
         if (ret == 0) {
             MessageBoxInfo(tr("Requesting permission"), tr("Please Enter your password in the opened terminal, then try again"));
             return false;
         } else {
-            MW_show_log(QString("Failed to run %1 with %2").arg(Command).arg(ret));
+            MW_show_log(QString("Failed to request privileges for %1 with %2").arg(corePath).arg(ret));
             return false;
         }
     }

--- a/src/ui/utils/DataViewHtmlGenerator.cpp
+++ b/src/ui/utils/DataViewHtmlGenerator.cpp
@@ -76,12 +76,12 @@ QString DataViewHtmlGenerator::downloadSectionHtml() {
     const QString stat =
         ReadableSize(download_.report.downloadedSize) + "/" + ReadableSize(download_.report.totalSize);
     return QString("<p style='text-align:center;margin:0;'>Downloading %1: %2 %3</p>")
-        .arg(download_.report.fileName, stat, progressText);
+        .arg(download_.report.fileName.toHtmlEscaped(), stat, progressText);
 }
 
 QString DataViewHtmlGenerator::speedtestSectionHtml() {
     if (speedtest_.kind == SpeedtestPanelState::Kind::Speed) {
-        auto firstLine = QStringLiteral("Running Speedtest: %1").arg(speedtest_.profileName);
+        auto firstLine = QStringLiteral("Running Speedtest: %1").arg(speedtest_.profileName.toHtmlEscaped());
         if (speedtest_.totalProfiles > 1) {
             firstLine += QString(" (%1 / %2)").arg(Int2String(testProgress.load()), Int2String(speedtest_.totalProfiles));
         }
@@ -93,8 +93,9 @@ QString DataViewHtmlGenerator::speedtestSectionHtml() {
            "<span style='color: #86C43F;'>Ul↑ %3</span>"
            "</div>"
            "<p style='text-align:center;margin:0;'>Server: %4%5, %6</p>")
-            .arg(firstLine, speedtest_.dlSpeed, speedtest_.ulSpeed, speedtest_.serverCountryFlag, speedtest_.serverCountry,
-                speedtest_.serverName);
+            .arg(firstLine, speedtest_.dlSpeed.toHtmlEscaped(), speedtest_.ulSpeed.toHtmlEscaped(),
+                speedtest_.serverCountryFlag, speedtest_.serverCountry.toHtmlEscaped(),
+                speedtest_.serverName.toHtmlEscaped());
     } else {
         QString res;
         auto content = QString("Running Country Test");


### PR DESCRIPTION
## Summary

Addresses several security findings from an audit, spanning privilege
elevation, the update channel, the build supply chain, and HTML rendering.

## Changes

### Command injection in privilege-elevation commands
`Linux_Run_Command` and `Mac_Run_Command` built a shell string from the core
binary path and ran it via `system()`. An install/launch directory containing
shell metacharacters (e.g. `.../x;touch /etc/evil`) would inject into a command
executed as **root** through `pkexec`/`sudo`.
- **Linux:** `Linux_Run_Command` now takes a `QStringList` and runs `pkexec`
  via `QProcess::execute` with an explicit argument list (no shell).
- **macOS:** drops the outer `system()`/`sh` layer by invoking `osascript`
  through `QProcess`; the path is shell-quoted and AppleScript-escaped so it is
  safe through the Terminal `do script` nesting.

### Update channel (MITM → RCE)
- Add a `forceSecure` flag to `HttpGet`/`DownloadAsset` that overrides the
  global `net_insecure` setting and always enforces TLS verification.
- Use it for the update check and payload download, so enabling `net_insecure`
  for subscriptions can no longer disable cert checks on the updater.
- Validate the asset URL before download: reject non-`https` or hosts outside
  `github.com` / `githubusercontent.com`, blocking a tampered API response from
  redirecting the payload.

### Build supply chain
- Verify the SHA-256 of fetched prebuilt binaries (updater, `libcronet.dll`) in
  `build_go.sh` against pins in `script/deps.sha256`; fail closed on mismatch,
  missing, or unfilled hash.
- Add `script/deps.sha256` (placeholders to be populated with real hashes).

### HTML output
- HTML-escape attacker-controlled values (profile name, server name/country,
  speeds, download filename) in `DataViewHtmlGenerator` before they reach the
  `QTextBrowser` data view.

## Notes
- The `script/deps.sha256` placeholders must be filled with real hashes before
  release.
- The privilege-elevation changes touch Linux/macOS-only `#ifdef` blocks and
  were not compiled on those platforms here — worth a build on each target to confirm.