### PR TITLE
fix: display server address or type in tray menu for unnamed profiles

### DIFF
--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -666,7 +666,19 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
                     auto profiles = group->Profiles();
                     auto neededProfilesIDNames = Configs::dataManager->profilesRepo->GetProfileIDNameMappedBatch(profiles);
                     for (const auto&[id, name] : neededProfilesIDNames) {
-                        auto *action = groupMenu->addAction(name);
+                        QString displayName = name;
+                        std::shared_ptr<Configs::Profile> profile;
+                        if (displayName.isEmpty()) {
+                            profile = Configs::dataManager->profilesRepo->GetProfile(id);
+                            if (profile && profile->outbound) {
+                                displayName = profile->outbound->DisplayName();
+                            }
+                        }
+                        if (displayName.isEmpty()) {
+                            QString pType = profile ? profile->type : QStringLiteral("unknown");
+                            displayName = QString("[%1] (ID: %2)").arg(pType, QString::number(id));
+                        }
+                        auto *action = groupMenu->addAction(displayName);
                         action->setCheckable(true);
                         action->setChecked(running && running->id == id);
                         connect(action, &QAction::triggered, this, [=, this]() { profile_start(id); });
@@ -1336,7 +1348,19 @@ void MainWindow::rebuildTrayServerMenu() {
     for (int i = start; i < end; ++i) pageIds.append(profiles[i]);
     auto mappedIdNames = Configs::dataManager->profilesRepo->GetProfileIDNameMappedBatch(pageIds);
     for (const auto&[id, name] : mappedIdNames) {
-        auto *action = trayServerMenu->addAction(name);
+        QString displayName = name;
+        std::shared_ptr<Configs::Profile> profile;
+        if (displayName.isEmpty()) {
+            profile = Configs::dataManager->profilesRepo->GetProfile(id);
+            if (profile && profile->outbound) {
+                displayName = profile->outbound->DisplayName();
+            }
+        }
+        if (displayName.isEmpty()) {
+            QString pType = profile ? profile->type : QStringLiteral("unknown");
+            displayName = QString("[%1] (ID: %2)").arg(pType, QString::number(id));
+        }
+        auto *action = trayServerMenu->addAction(displayName);
         action->setCheckable(true);
         action->setChecked(running && running->id == id);
         connect(action, &QAction::triggered, this, [=, this]() { profile_start(id); });

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -664,19 +664,20 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
                 connect(groupMenu, &QMenu::aboutToShow, this, [=, this]() {
                     groupMenu->clear();
                     auto profiles = group->Profiles();
+                    Configs::dataManager->profilesRepo->GetProfileBatch(profiles);
                     auto neededProfilesIDNames = Configs::dataManager->profilesRepo->GetProfileIDNameMappedBatch(profiles);
                     for (const auto&[id, name] : neededProfilesIDNames) {
                         QString displayName = name;
                         std::shared_ptr<Configs::Profile> profile;
-                        if (displayName.isEmpty()) {
+                        if (displayName.trimmed().isEmpty()) {
                             profile = Configs::dataManager->profilesRepo->GetProfile(id);
                             if (profile && profile->outbound) {
                                 displayName = profile->outbound->DisplayName();
                             }
                         }
-                        if (displayName.isEmpty()) {
-                            QString pType = profile ? profile->type : QStringLiteral("unknown");
-                            displayName = QString("[%1] (ID: %2)").arg(pType, QString::number(id));
+                        if (displayName.trimmed().isEmpty()) {
+                            const QString pType = (profile && profile->outbound && !profile->outbound->DisplayType().isEmpty()) ? profile->outbound->DisplayType() : ((profile && !profile->type.isEmpty()) ? profile->type : tr("unknown"));
+                            displayName = tr("[%1] (ID: %2)").arg(pType, QString::number(id));
                         }
                         auto *action = groupMenu->addAction(displayName);
                         action->setCheckable(true);
@@ -1346,19 +1347,20 @@ void MainWindow::rebuildTrayServerMenu() {
     QList<int> pageIds;
     pageIds.reserve(end - start);
     for (int i = start; i < end; ++i) pageIds.append(profiles[i]);
+    Configs::dataManager->profilesRepo->GetProfileBatch(pageIds);
     auto mappedIdNames = Configs::dataManager->profilesRepo->GetProfileIDNameMappedBatch(pageIds);
     for (const auto&[id, name] : mappedIdNames) {
         QString displayName = name;
         std::shared_ptr<Configs::Profile> profile;
-        if (displayName.isEmpty()) {
+        if (displayName.trimmed().isEmpty()) {
             profile = Configs::dataManager->profilesRepo->GetProfile(id);
             if (profile && profile->outbound) {
                 displayName = profile->outbound->DisplayName();
             }
         }
-        if (displayName.isEmpty()) {
-            QString pType = profile ? profile->type : QStringLiteral("unknown");
-            displayName = QString("[%1] (ID: %2)").arg(pType, QString::number(id));
+        if (displayName.trimmed().isEmpty()) {
+            const QString pType = (profile && profile->outbound && !profile->outbound->DisplayType().isEmpty()) ? profile->outbound->DisplayType() : ((profile && !profile->type.isEmpty()) ? profile->type : tr("unknown"));
+            displayName = tr("[%1] (ID: %2)").arg(pType, QString::number(id));
         }
         auto *action = trayServerMenu->addAction(displayName);
         action->setCheckable(true);


### PR DESCRIPTION
### Description
This PR resolves the issue where profiles without names are displayed as empty/blank lines in the system tray menu. 

### Changes
- Updated `rebuildTrayServerMenu` and the macOS tray setup in `MainWindow` to check if the profile's display name is empty.
- If it is empty, it falls back to the profile's server address (using `profile->outbound->DisplayName()`).
- If the server address is also empty (e.g. for `direct` or `custom` profiles), it falls back to displaying the outbound type and database ID: `[Type] (ID: <id>)`, guaranteeing that every profile has a unique and readable entry in the tray menu.

Fixes #1584
