### PR TITLE
fix: keep Start/Stop button active after manual stop

### DIFF
--- a/include/ui/mainwindow.h
+++ b/include/ui/mainwindow.h
@@ -75,6 +75,8 @@ public:
 
     void profile_stop(bool crash = false, bool block = false, bool manual = false);
 
+    int get_profile_to_start();
+
     void set_spmode_system_proxy(bool enable, bool save = true);
 
     void toggle_system_proxy();
@@ -208,6 +210,7 @@ private:
     QString title_error;
     int icon_status = -1;
     std::shared_ptr<Configs::Profile> running;
+    int last_running_profile_id = -1;
     // True from the moment a profile start is kicked off until it succeeds or
     // fails; drives the start/stop button's transient "Connecting" state.
     bool m_profileConnecting = false;

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -187,6 +187,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     setActionsData();
     loadShortcuts();
 
+    last_running_profile_id = Configs::dataManager->settingsRepo->remember_id;
+
     // geometry remembering
     if (!Configs::dataManager->settingsRepo->mainWindowGeometry.isEmpty()) {
         auto geo = DecodeB64IfValid(Configs::dataManager->settingsRepo->mainWindowGeometry);
@@ -2299,8 +2301,8 @@ void MainWindow::refresh_startstop_button() {
     if (m_profileConnecting) state = StartStopButton::State::Connecting;
     else if (m_profileDisconnecting) state = StartStopButton::State::Disconnecting;
     else if (running != nullptr) state = StartStopButton::State::Running;
-    else if (get_now_selected_list().size() == 1) state = StartStopButton::State::Idle;
-    else state = StartStopButton::State::Disabled; // nothing, or multiple, selected
+    else if (get_profile_to_start() >= 0) state = StartStopButton::State::Idle;
+    else state = StartStopButton::State::Disabled;
     btn->setState(state);
 }
 

--- a/src/ui/mainwindow_rpc.cpp
+++ b/src/ui/mainwindow_rpc.cpp
@@ -727,6 +727,33 @@ void MainWindow::checkDefaultInterfaceChange() {
     profile_start(startedId);
 }
 
+int MainWindow::get_profile_to_start() {
+    auto ents = get_now_selected_list();
+    if (ents.size() == 1) {
+        return ents.first();
+    }
+    if (ents.isEmpty()) {
+        if (last_running_profile_id >= 0 && Configs::dataManager->profilesRepo->GetProfile(last_running_profile_id) != nullptr) {
+            return last_running_profile_id;
+        }
+        int rememberId = Configs::dataManager->settingsRepo->remember_id;
+        if (rememberId >= 0 && Configs::dataManager->profilesRepo->GetProfile(rememberId) != nullptr) {
+            return rememberId;
+        }
+        auto currentGroup = Configs::dataManager->groupsRepo->CurrentGroup();
+        if (currentGroup) {
+            auto profiles = currentGroup->Profiles();
+            if (!profiles.isEmpty()) {
+                int firstId = profiles.first();
+                if (Configs::dataManager->profilesRepo->GetProfile(firstId) != nullptr) {
+                    return firstId;
+                }
+            }
+        }
+    }
+    return -1;
+}
+
 void MainWindow::profile_start(int _id) {
     if (Configs::dataManager->settingsRepo->prepare_exit) return;
 #ifdef Q_OS_LINUX
@@ -738,9 +765,18 @@ void MainWindow::profile_start(int _id) {
     }
 #endif
 
-    auto ents = get_now_selected_list();
-    auto ent = (_id < 0 && !ents.isEmpty()) ? Configs::dataManager->profilesRepo->GetProfile(ents.first()) : Configs::dataManager->profilesRepo->GetProfile(_id);
+    Database::ProfileEntity *ent = nullptr;
+    if (_id >= 0) {
+        ent = Configs::dataManager->profilesRepo->GetProfile(_id);
+    } else {
+        int startId = get_profile_to_start();
+        if (startId >= 0) {
+            ent = Configs::dataManager->profilesRepo->GetProfile(startId);
+        }
+    }
     if (ent == nullptr) return;
+
+    last_running_profile_id = ent->id;
 
     if (select_mode) {
         emit profile_selected(ent->id);

--- a/src/ui/mainwindow_rpc.cpp
+++ b/src/ui/mainwindow_rpc.cpp
@@ -765,7 +765,7 @@ void MainWindow::profile_start(int _id) {
     }
 #endif
 
-    Database::ProfileEntity *ent = nullptr;
+    std::shared_ptr<Configs::Profile> ent = nullptr;
     if (_id >= 0) {
         ent = Configs::dataManager->profilesRepo->GetProfile(_id);
     } else {


### PR DESCRIPTION
### Motivation

Manually stopping a connection via the Start/Stop button disables the button if no profile is currently highlighted in the list. This breaks the quick-toggle UX, forcing the user to manually select a profile to reconnect. 

This PR keeps the button active (`Idle`) by falling back to the last active profile or the first profile in the group if selection is empty.

### Changes

- **Session Memory**: Added `last_running_profile_id` to track the last running profile within the active application session.
- **Start/Stop UI State**: Updated `MainWindow::refresh_startstop_button()` to transition to `Idle` (enabled) if a valid profile can be resolved, instead of strictly requiring a single selection in the profile list view.
- **Smart Start Candidate Resolver**: Implemented `MainWindow::get_profile_to_start()` which resolves the profile to start in the following priority:
  1. The selected profile in the main window table (if exactly one is highlighted).
  2. The `last_running_profile_id` (the last profile run in this session).
  3. The `remember_id` from settings.
  4. The first profile in the current group.
- **Dynamic Target Tracking**: Updated `MainWindow::profile_start()` to resolve the start profile via `get_profile_to_start()` and update `last_running_profile_id` upon successful start.
