### PR TITLE
feat: enlarge tray menu buttons for improved UX

### DIFF
--- a/include/database/SettingsRepo.h
+++ b/include/database/SettingsRepo.h
@@ -115,6 +115,7 @@ namespace Configs {
         bool show_system_dns = false;
         bool use_custom_icons = false;
         bool skip_delete_confirmation = false;
+        bool enlarge_tray_menu = false;
 
         // throne:// URL scheme: mirror of what we last wrote to the OS (registry/desktop/bundle).
         // Re-registered on startup only when the current state differs (e.g. install moved).

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -683,6 +683,13 @@ QTabBar::tab:hover:!selected {
               </property>
              </widget>
             </item>
+            <item>
+             <widget class="QCheckBox" name="enlarge_tray_menu">
+              <property name="text">
+               <string>Enlarge tray menu buttons</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/src/database/SettingsRepo.cpp
+++ b/src/database/SettingsRepo.cpp
@@ -51,6 +51,7 @@ namespace Configs {
             {"xray_mux_default_on",           &xray_mux_default_on},
             {"use_dns_object",                &use_dns_object},
             {"skip_delete_confirmation",      &skip_delete_confirmation},
+            {"enlarge_tray_menu",             &enlarge_tray_menu},
             {"log_enable_include",            &log_enable_include},
             {"log_enable_exclude",            &log_enable_exclude},
             {"log_auto_scroll",               &log_auto_scroll},

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -113,6 +113,7 @@ void UI_InitMainWindow() {
 
 namespace {
 constexpr int kExtraItemHeight = 18;
+constexpr int kTrayFontAddition = 2;
 
 class TrayMenuProxyStyle : public QProxyStyle {
     bool m_submenusOnly;
@@ -134,7 +135,7 @@ public:
 
                 if (enlarge) {
                     QStyleOptionMenuItem largerOpt = *menuOpt;
-                    largerOpt.font.setPointSize(largerOpt.font.pointSize() + 3);
+                    largerOpt.font.setPointSize(largerOpt.font.pointSize() + kTrayFontAddition);
                     QSize sz = QProxyStyle::sizeFromContents(type, &largerOpt, size, widget);
                     
                     // Manually calculate text width difference because base style might ignore option->font
@@ -167,7 +168,7 @@ public:
 
                 if (enlarge) {
                     QStyleOptionMenuItem largerOpt = *menuOpt;
-                    largerOpt.font.setPointSize(largerOpt.font.pointSize() + 3);
+                    largerOpt.font.setPointSize(largerOpt.font.pointSize() + kTrayFontAddition);
                     QProxyStyle::drawControl(element, &largerOpt, painter, widget);
                     return;
                 }

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -668,11 +668,17 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     this->refresh_groups();
 
     // Setup Tray
+    auto &settings = Configs::dataManager->settingsRepo;
     tray = new QSystemTrayIcon(nullptr);
     tray->setIcon(GetTrayIcon(Icon::NONE));
     QApplication::setWindowIcon(Icon::GetTrayIcon(Icon::NONE));
     trayMenu = new QMenu();
-    trayMenu->setStyle(new TrayMenuProxyStyle(trayMenu, true));
+    if (settings->enlarge_tray_menu) {
+        trayMenu->setStyle(new TrayMenuProxyStyle(trayMenu, true));
+        QFont f = trayMenu->font();
+        f.setPointSize(f.pointSize() + 1);
+        trayMenu->setFont(f);
+    }
     trayMenu->addAction(ui->actionShow_window);
     trayMenu->addSeparator();
     trayMenu->addAction(ui->actionStart_with_system);
@@ -681,6 +687,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     trayMenu->addSeparator();
     // Select Server submenu (dynamically populated by groups)
     trayServerMenu = new StayOpenMenu(tr("Select Server"));
+    if (settings->enlarge_tray_menu) {
+        trayServerMenu->setFont(trayMenu->font());
+    }
     trayMenu->addMenu(trayServerMenu);
     trayMenu->installEventFilter(this);
     connect(trayServerMenu, &QMenu::aboutToShow, this, [=, this]() {
@@ -728,7 +737,10 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     // MacOS cannot reuse menus across different parents properly
     if (getOS() == Darwin) {
         auto* traySpmodeMenu = new QMenu(ui->menu_spmode->title(), trayMenu);
-        traySpmodeMenu->setStyle(new TrayMenuProxyStyle(traySpmodeMenu));
+        if (settings->enlarge_tray_menu) {
+            traySpmodeMenu->setStyle(new TrayMenuProxyStyle(traySpmodeMenu));
+            traySpmodeMenu->setFont(trayMenu->font());
+        }
         traySpmodeMenu->addAction(ui->menu_spmode_system_proxy);
         traySpmodeMenu->addAction(ui->menu_spmode_vpn);
         traySpmodeMenu->addAction(ui->menu_spmode_disabled);
@@ -739,12 +751,18 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         });
         trayMenu->addMenu(traySpmodeMenu);
     } else {
-        ui->menu_spmode->setStyle(new TrayMenuProxyStyle(ui->menu_spmode));
+        if (settings->enlarge_tray_menu) {
+            ui->menu_spmode->setStyle(new TrayMenuProxyStyle(ui->menu_spmode));
+            ui->menu_spmode->setFont(trayMenu->font());
+        }
         trayMenu->addMenu(ui->menu_spmode);
     }
 
     auto* trayRoutingMenu = new QMenu(tr("Select Routing"), trayMenu);
-    trayRoutingMenu->setStyle(new TrayMenuProxyStyle(trayRoutingMenu));
+    if (settings->enlarge_tray_menu) {
+        trayRoutingMenu->setStyle(new TrayMenuProxyStyle(trayRoutingMenu));
+        trayRoutingMenu->setFont(trayMenu->font());
+    }
     connect(trayRoutingMenu, &QMenu::aboutToShow, this, [=,this]() {
         trayRoutingMenu->clear();
         for (const auto& route : Configs::dataManager->routesRepo->GetAllRouteProfiles()) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -80,6 +80,8 @@
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #include <QStyleHints>
 #endif
+#include <QProxyStyle>
+#include <QStyleOptionMenuItem>
 #include <QFileDialog>
 #include <QToolTip>
 #include <QMimeData>
@@ -106,6 +108,33 @@ dialog->show();
 void UI_InitMainWindow() {
     mainwindow = new MainWindow;
 }
+
+namespace {
+constexpr int kExtraItemHeight = 18;
+
+class TrayMenuProxyStyle : public QProxyStyle {
+    bool m_submenusOnly;
+public:
+    explicit TrayMenuProxyStyle(QObject *parent = nullptr, bool submenusOnly = false)
+        : QProxyStyle(), m_submenusOnly(submenusOnly) {
+        setParent(parent);
+    }
+
+    QSize sizeFromContents(ContentsType type, const QStyleOption *option, const QSize &size, const QWidget *widget) const override {
+        QSize sz = QProxyStyle::sizeFromContents(type, option, size, widget);
+        if (type == CT_MenuItem) {
+            if (!m_submenusOnly) {
+                sz.setHeight(sz.height() + kExtraItemHeight);
+            } else if (const auto *menuOpt = qstyleoption_cast<const QStyleOptionMenuItem *>(option)) {
+                if (menuOpt->menuItemType == QStyleOptionMenuItem::SubMenu) {
+                    sz.setHeight(sz.height() + kExtraItemHeight);
+                }
+            }
+        }
+        return sz;
+    }
+};
+} // namespace
 
 // Caller must hold coreProcessMutex (reads core_process lock-free by design).
 bool MainWindow::verify_core_pid(QLocalSocket *socket) {
@@ -639,6 +668,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     tray->setIcon(GetTrayIcon(Icon::NONE));
     QApplication::setWindowIcon(Icon::GetTrayIcon(Icon::NONE));
     trayMenu = new QMenu();
+    trayMenu->setStyle(new TrayMenuProxyStyle(trayMenu, true));
     trayMenu->addAction(ui->actionShow_window);
     trayMenu->addSeparator();
     trayMenu->addAction(ui->actionStart_with_system);
@@ -694,6 +724,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     // MacOS cannot reuse menus across different parents properly
     if (getOS() == Darwin) {
         auto* traySpmodeMenu = new QMenu(ui->menu_spmode->title(), trayMenu);
+        traySpmodeMenu->setStyle(new TrayMenuProxyStyle(traySpmodeMenu));
         traySpmodeMenu->addAction(ui->menu_spmode_system_proxy);
         traySpmodeMenu->addAction(ui->menu_spmode_vpn);
         traySpmodeMenu->addAction(ui->menu_spmode_disabled);
@@ -704,10 +735,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         });
         trayMenu->addMenu(traySpmodeMenu);
     } else {
+        ui->menu_spmode->setStyle(new TrayMenuProxyStyle(ui->menu_spmode));
         trayMenu->addMenu(ui->menu_spmode);
     }
 
     auto* trayRoutingMenu = new QMenu(tr("Select Routing"), trayMenu);
+    trayRoutingMenu->setStyle(new TrayMenuProxyStyle(trayRoutingMenu));
     connect(trayRoutingMenu, &QMenu::aboutToShow, this, [=,this]() {
         trayRoutingMenu->clear();
         for (const auto& route : Configs::dataManager->routesRepo->GetAllRouteProfiles()) {

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -2,6 +2,7 @@
 
 #include <QAbstractItemView>
 #include <QMenu>
+#include <QPainter>
 #include <ranges>
 
 #include "include/configs/sub/GroupUpdater.hpp"
@@ -122,17 +123,57 @@ public:
     }
 
     QSize sizeFromContents(ContentsType type, const QStyleOption *option, const QSize &size, const QWidget *widget) const override {
-        QSize sz = QProxyStyle::sizeFromContents(type, option, size, widget);
         if (type == CT_MenuItem) {
-            if (!m_submenusOnly) {
-                sz.setHeight(sz.height() + kExtraItemHeight);
-            } else if (const auto *menuOpt = qstyleoption_cast<const QStyleOptionMenuItem *>(option)) {
-                if (menuOpt->menuItemType == QStyleOptionMenuItem::SubMenu) {
+            if (const auto *menuOpt = qstyleoption_cast<const QStyleOptionMenuItem *>(option)) {
+                bool enlarge = false;
+                if (!m_submenusOnly) {
+                    enlarge = true;
+                } else if (menuOpt->menuItemType == QStyleOptionMenuItem::SubMenu) {
+                    enlarge = true;
+                }
+
+                if (enlarge) {
+                    QStyleOptionMenuItem largerOpt = *menuOpt;
+                    largerOpt.font.setPointSize(largerOpt.font.pointSize() + 3);
+                    QSize sz = QProxyStyle::sizeFromContents(type, &largerOpt, size, widget);
+                    
+                    // Manually calculate text width difference because base style might ignore option->font
+                    QFontMetrics fm(largerOpt.font);
+                    QFontMetrics fmDefault(menuOpt->font);
+                    int widthLarger = fm.horizontalAdvance(largerOpt.text);
+                    int widthDefault = fmDefault.horizontalAdvance(menuOpt->text);
+                    int diffWidth = widthLarger - widthDefault;
+                    if (diffWidth > 0) {
+                        sz.setWidth(sz.width() + diffWidth);
+                    }
+
                     sz.setHeight(sz.height() + kExtraItemHeight);
+                    return sz;
                 }
             }
         }
-        return sz;
+        return QProxyStyle::sizeFromContents(type, option, size, widget);
+    }
+
+    void drawControl(ControlElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget) const override {
+        if (element == CE_MenuItem) {
+            if (const auto *menuOpt = qstyleoption_cast<const QStyleOptionMenuItem *>(option)) {
+                bool enlarge = false;
+                if (!m_submenusOnly) {
+                    enlarge = true;
+                } else if (menuOpt->menuItemType == QStyleOptionMenuItem::SubMenu) {
+                    enlarge = true;
+                }
+
+                if (enlarge) {
+                    QStyleOptionMenuItem largerOpt = *menuOpt;
+                    largerOpt.font.setPointSize(largerOpt.font.pointSize() + 3);
+                    QProxyStyle::drawControl(element, &largerOpt, painter, widget);
+                    return;
+                }
+            }
+        }
+        QProxyStyle::drawControl(element, option, painter, widget);
     }
 };
 } // namespace
@@ -675,9 +716,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     trayMenu = new QMenu();
     if (settings->enlarge_tray_menu) {
         trayMenu->setStyle(new TrayMenuProxyStyle(trayMenu, true));
-        QFont f = trayMenu->font();
-        f.setPointSize(f.pointSize() + 1);
-        trayMenu->setFont(f);
     }
     trayMenu->addAction(ui->actionShow_window);
     trayMenu->addSeparator();
@@ -687,9 +725,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     trayMenu->addSeparator();
     // Select Server submenu (dynamically populated by groups)
     trayServerMenu = new StayOpenMenu(tr("Select Server"));
-    if (settings->enlarge_tray_menu) {
-        trayServerMenu->setFont(trayMenu->font());
-    }
     trayMenu->addMenu(trayServerMenu);
     trayMenu->installEventFilter(this);
     connect(trayServerMenu, &QMenu::aboutToShow, this, [=, this]() {
@@ -738,8 +773,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     if (getOS() == Darwin) {
         auto* traySpmodeMenu = new QMenu(ui->menu_spmode->title(), trayMenu);
         if (settings->enlarge_tray_menu) {
-            traySpmodeMenu->setStyle(new TrayMenuProxyStyle(traySpmodeMenu));
-            traySpmodeMenu->setFont(trayMenu->font());
+            traySpmodeMenu->setStyle(new TrayMenuProxyStyle(traySpmodeMenu, false));
         }
         traySpmodeMenu->addAction(ui->menu_spmode_system_proxy);
         traySpmodeMenu->addAction(ui->menu_spmode_vpn);
@@ -752,16 +786,14 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         trayMenu->addMenu(traySpmodeMenu);
     } else {
         if (settings->enlarge_tray_menu) {
-            ui->menu_spmode->setStyle(new TrayMenuProxyStyle(ui->menu_spmode));
-            ui->menu_spmode->setFont(trayMenu->font());
+            ui->menu_spmode->setStyle(new TrayMenuProxyStyle(ui->menu_spmode, false));
         }
         trayMenu->addMenu(ui->menu_spmode);
     }
 
     auto* trayRoutingMenu = new QMenu(tr("Select Routing"), trayMenu);
     if (settings->enlarge_tray_menu) {
-        trayRoutingMenu->setStyle(new TrayMenuProxyStyle(trayRoutingMenu));
-        trayRoutingMenu->setFont(trayMenu->font());
+        trayRoutingMenu->setStyle(new TrayMenuProxyStyle(trayRoutingMenu, false));
     }
     connect(trayRoutingMenu, &QMenu::aboutToShow, this, [=,this]() {
         trayRoutingMenu->clear();

--- a/src/ui/setting/dialog_basic_settings.cpp
+++ b/src/ui/setting/dialog_basic_settings.cpp
@@ -118,9 +118,13 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     //
     D_LOAD_BOOL(start_minimal)
     ui->skip_delete_confirm->setChecked(Configs::dataManager->settingsRepo->skip_delete_confirmation);
+    D_LOAD_BOOL(enlarge_tray_menu)
     //
     ui->language->setCurrentIndex(Configs::dataManager->settingsRepo->language);
     connect(ui->language, &QComboBox::currentIndexChanged, this, [=,this](int index) {
+        CACHE.needRestart = true;
+    });
+    connect(ui->enlarge_tray_menu, &QCheckBox::stateChanged, this, [=,this](const bool &) {
         CACHE.needRestart = true;
     });
     connect(ui->font, &QComboBox::currentTextChanged, this, [=,this](const QString &fontName) {
@@ -354,6 +358,7 @@ void DialogBasicSettings::accept() {
     D_SAVE_BOOL(start_minimal)
     Configs::dataManager->settingsRepo->skip_delete_confirmation = ui->skip_delete_confirm->isChecked();
     Configs::dataManager->settingsRepo->show_system_dns = ui->show_sys_dns->isChecked();
+    D_SAVE_BOOL(enlarge_tray_menu)
 
     if (Configs::dataManager->settingsRepo->max_log_line <= 0) {
         Configs::dataManager->settingsRepo->max_log_line = 200;


### PR DESCRIPTION
### Motivation

I frequently use the system tray context menu to switch servers, proxy modes, and routing profiles during daily usage. The standard system tray menu items can be small and easy to miss, breaking quick-toggle UX.

I really wanted to improve the tray navigation UX, and increasing the button height was the best idea I could come up with. Feel free to suggest a better approach.

This PR increases the click target size (vertical item height) for primary tray menu actions while preserving standard text proportions.

### Changes

- **Increased Click Target Height**: Applied custom `QProxyStyle` in `src/ui/mainwindow.cpp` to enlarge the vertical button height (~2x height) for the primary tray submenus (`Select Server`, `System Proxy`, `Select Routing`).
- **Selective Submenu Proportions**: Enlarged item height inside the `System Proxy` and `Select Routing` submenus for quick toggling, while keeping the `Select Server` submenu at default compact height since server lists are often very long and changed less frequently.