### PR TITLE
Add "Auto Balance Group" action (URL test → remove unavailable → speed test)

### DIFF
--- a/include/ui/mainwindow.h
+++ b/include/ui/mainwindow.h
@@ -397,7 +397,9 @@ private:
 
     bool verify_core_pid(QLocalSocket *socket);
 
-    void urltest_current_group(const QList<int>& profileIDs);
+    void urltest_current_group(const QList<int>& profileIDs, const std::function<void()>& onDone = nullptr);
+
+    void autobalance_current_group();
 
     void iptest_current_group(const QList<int>& profileIDs);
 

--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -797,6 +797,7 @@ QTabBar::tab:selected {
     <addaction name="menu_clear_test_result"/>
     <addaction name="menu_delete_repeat"/>
     <addaction name="actionSpeedtest_Group"/>
+    <addaction name="actionAuto_Balance_Group"/>
     <addaction name="actionResolve_Out_IP"/>
     <addaction name="actionRefresh_Column_Widths"/>
    </widget>
@@ -819,6 +820,7 @@ QTabBar::tab:selected {
     <addaction name="actionSpeedtest_Current"/>
     <addaction name="actionUrl_Test_Group"/>
     <addaction name="actionSpeedtest_Group"/>
+    <addaction name="actionAuto_Balance_Group"/>
     <addaction name="actionResolve_Out_IP"/>
     <addaction name="menu_resolve_domain"/>
     <addaction name="menu_clear_test_result"/>
@@ -1226,6 +1228,17 @@ QTabBar::tab:selected {
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+P</string>
+   </property>
+  </action>
+  <action name="actionAuto_Balance_Group">
+   <property name="text">
+    <string>Auto Balance Group</string>
+   </property>
+   <property name="toolTip">
+    <string>URL test the group, remove unavailable profiles, then run a speed test</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+Shift+B</string>
    </property>
   </action>
   <action name="actionSpeedtest_Group">

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -978,6 +978,10 @@ connect(ui->actionRestart_Proxy, &QAction::triggered, this, [=,this] {
     {
         speedtest_current_group(Configs::dataManager->groupsRepo->CurrentGroup()->Profiles());
     });
+    connect(ui->actionAuto_Balance_Group, &QAction::triggered, this, [=,this]()
+    {
+        autobalance_current_group();
+    });
     connect(ui->actionResolve_Selected_Out_IP, &QAction::triggered, this, [=,this]() {
         iptest_current_group(get_now_selected_list());
     });

--- a/src/ui/mainwindow_rpc.cpp
+++ b/src/ui/mainwindow_rpc.cpp
@@ -265,7 +265,7 @@ void MainWindow::runIPTest(const QString& config, const QString& xrayConfig, boo
     }
 }
 
-void MainWindow::urltest_current_group(const QList<int>& profileIDs) {
+void MainWindow::urltest_current_group(const QList<int>& profileIDs, const std::function<void()>& onDone) {
     if (profileIDs.isEmpty()) {
         return;
     }
@@ -274,7 +274,7 @@ void MainWindow::urltest_current_group(const QList<int>& profileIDs) {
         return;
     }
 
-    runOnNewThread([this, profileIDs]() {
+    runOnNewThread([this, profileIDs, onDone]() {
         stopSpeedtest.store(false);
         dataViewHtmlGenerator_.seedLatencyTest(DataViewHtmlGenerator::LatencyTestPanelState::Kind::Url, profileIDs.size());
         UpdateDataView(true);
@@ -331,13 +331,50 @@ void MainWindow::urltest_current_group(const QList<int>& profileIDs) {
         dataViewHtmlGenerator_.clearTestSections();
         UpdateDataView(true);
         speedtestRunning.unlock();
-        if (currentGroup->auto_clear_unavailable) {
+        if (currentGroup && currentGroup->auto_clear_unavailable) {
             MW_show_log("URL test finished, clearing unavailable profiles...");
             runOnUiThread([=, this] {
                clearUnavailableProfiles(false, profileIDs);
             });
         }
         MW_show_log(tr("URL test finished!"));
+        if (onDone) onDone();
+    });
+}
+
+void MainWindow::autobalance_current_group() {
+    auto group = Configs::dataManager->groupsRepo->CurrentGroup();
+    if (!group) return;
+    auto profileIDs = group->Profiles();
+    if (profileIDs.isEmpty()) {
+        MW_show_log(tr("Auto balance: the current group is empty."));
+        return;
+    }
+    auto gid = group->id;
+    MW_show_log(tr("Auto balance: step 1/3 - URL test for %1 profile(s)...").arg(profileIDs.size()));
+    urltest_current_group(profileIDs, [this, gid, profileIDs]() {
+        // Runs on the urltest worker thread after the test has fully finished
+        // and the speedtestRunning mutex has been released.
+        runOnUiThread([this, gid, profileIDs] {
+            if (stopSpeedtest.load()) {
+                MW_show_log(tr("Auto balance: aborted."));
+                return;
+            }
+            auto group = Configs::dataManager->groupsRepo->GetGroup(gid);
+            if (!group || Configs::dataManager->groupsRepo->CurrentGroup()->id != gid) {
+                MW_show_log(tr("Auto balance: group changed, aborting."));
+                return;
+            }
+            MW_show_log(tr("Auto balance: step 2/3 - removing unavailable profiles..."));
+            clearUnavailableProfiles(false, profileIDs);
+            auto remaining = group->Profiles();
+            if (remaining.isEmpty()) {
+                MW_show_log(tr("Auto balance: no available profiles left after cleanup."));
+                return;
+            }
+            MW_show_log(tr("Auto balance: step 3/3 - speed test for %1 profile(s)...").arg(remaining.size()));
+            speedtest_current_group(remaining);
+        });
     });
 }
 


### PR DESCRIPTION
Adds a one-click action (Testing menu + group context menu, Ctrl+Shift+B) that chains existing functionality: URL test for the current group → remove unavailable profiles → speed test for the remaining ones. Implemented via an optional completion callback in urltest_current_group(), no behavior changes for existing actions.
<img width="223" height="222" alt="p1" src="https://github.com/user-attachments/assets/9826dac1-bb39-4c15-b827-e2b09a47354f" />
<img width="940" height="47" alt="p2" src="https://github.com/user-attachments/assets/ab3a84ee-0fa9-406f-ab9d-7bbe7eaf8587" />
<img width="940" height="45" alt="p3" src="https://github.com/user-attachments/assets/e522a729-2fd5-423f-ad1a-ebc4ff19c0f4" />
<img width="940" height="49" alt="p4" src="https://github.com/user-attachments/assets/edf42643-0951-4a31-9961-f773923088f3" />
