### PR TITLE
fix custom sing-box outbound profiles not producing endpoints

### DIFF
--- a/include/configs/outbounds/custom.h
+++ b/include/configs/outbounds/custom.h
@@ -86,6 +86,15 @@ namespace Configs
             return type;
         };
 
+        bool IsEndpoint() override
+        {
+            // Only raw sing-box outbound JSON can describe an endpoint; Xray
+            // subtypes and full configs never do.
+            if (type != CustomOutbound) return false;
+            const auto t = QString2QJsonObject(config)["type"].toString();
+            return t == "wireguard" || t == "tailscale";
+        }
+
         bool IsXray() override { return type == CustomXrayOutbound; }
 
         bool IsXrayFullConfig() override { return type == CustomXrayFullConfig; }


### PR DESCRIPTION
Since sing-box 1.13, WireGuard (and Tailscale) only exist as endpoints; the legacy wireguard outbound type was removed. Custom (raw JSON) profiles always landed in the generated config's "outbounds" array because Configs::Custom never overrode IsEndpoint(), so such configs failed the config check with "address is unknown field".

Override IsEndpoint() to sniff the raw config's "type" field for the sing-box outbound subtype, mirroring how GetAddress() already inspects the JSON. Xray subtypes and full configs are unaffected.