### PR TITLE
Replace custom struct to system-type

### DIFF
--- a/src/sys/ProcessMetrics.cpp
+++ b/src/sys/ProcessMetrics.cpp
@@ -61,22 +61,7 @@ namespace {
             r.cpuNs = (k.QuadPart + u.QuadPart) * 100ULL;
         }
 
-        struct ProcMemCountersEx2 {
-            DWORD   cb;
-            DWORD   PageFaultCount;
-            SIZE_T  PeakWorkingSetSize;
-            SIZE_T  WorkingSetSize;
-            SIZE_T  QuotaPeakPagedPoolUsage;
-            SIZE_T  QuotaPagedPoolUsage;
-            SIZE_T  QuotaPeakNonPagedPoolUsage;
-            SIZE_T  QuotaNonPagedPoolUsage;
-            SIZE_T  PagefileUsage;
-            SIZE_T  PeakPagefileUsage;
-            SIZE_T  PrivateUsage;
-            SIZE_T  PrivateWorkingSetSize;
-            ULONG64 SharedCommitUsage;
-        };
-        ProcMemCountersEx2 ex2{};
+        PROCESS_MEMORY_COUNTERS_EX2 ex2{};
         ex2.cb = sizeof(ex2);
         if (GetProcessMemoryInfo(h, reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&ex2), sizeof(ex2))
             && ex2.PrivateWorkingSetSize > 0) {


### PR DESCRIPTION
_psapi.h_ contains `PROCESS_MEMORY_COUNTERS_EX2` struct.
https://learn.microsoft.com/en-us/windows/win32/api/psapi/ns-psapi-process_memory_counters_ex2

https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo#parameters

> [out] ppsmemCounters
> 
> A pointer to the [PROCESS_MEMORY_COUNTERS](https://learn.microsoft.com/en-us/windows/desktop/api/psapi/ns-psapi-process_memory_counters), [PROCESS_MEMORY_COUNTERS_EX](https://learn.microsoft.com/en-us/windows/desktop/api/psapi/ns-psapi-process_memory_counters_ex), or [PROCESS_MEMORY_COUNTERS_EX2](https://learn.microsoft.com/en-us/windows/desktop/api/psapi/ns-psapi-process_memory_counters_ex2) structure that receives information about the memory usage of the process.

Other types are not guaranteed to be acceptable.