### PR TITLE
Fix Linux CLI installer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Apple platforms have a very strict security policy and since Throne does not hav
 
 # Linux CLI installer
 ```bash
-curl -fsSL https://raw.githubusercontent.com/throneproj/Throne/main/script/install_linux.py | sudo python3
+curl -fsSL https://raw.githubusercontent.com/throneproj/Throne/dev/script/install_linux.py | sudo python3
 ```
 
 ### RPM repository

--- a/script/install_linux.py
+++ b/script/install_linux.py
@@ -220,9 +220,9 @@ def main(scr, y):
 
     releases = get_github_releases()
 
-    y = message(scr, y, f"Lastest Stable release: {releases['stable'][0]['version']}")
+    y = message(scr, y, f"Latest Stable release: {releases['stable'][0]['version']}")
     y = message(
-        scr, y, f"Lastest Unstable release: {releases['unstable'][0]['version']}"
+        scr, y, f"Latest Unstable release: {releases['unstable'][0]['version']}"
     )
 
     bar(scr, y, 0, "|", "", C_DIM)


### PR DESCRIPTION
Hiya! Thanks a lot for accepting:
- #1658

Opening this PR to fix installer link in `README.md`, I accidentally written it for `main` branch instead of Throne's default `dev` branch, which results in 404 from `curl`:
```bash
thearialume@fedora:~$ curl -fsSL https://raw.githubusercontent.com/throneproj/Throne/main/script/install_linux.py | sudo python3
curl: (22) The requested URL returned error: 404
```

New link works as intended:
```bash
thearialume@fedora:~$ curl -fsSL https://raw.githubusercontent.com/throneproj/Throne/dev/script/install_linux.py | sudo python3
┌  Welcome to Throne CLI manager!
|
> Looks like you already have Throne (1.1.6) installed
|
> Lastest Stable release: 1.1.6
> Lastest Unstable release: 1.2.0-beta.7
|
> What would you like to do?
│  > Install
│    Uninstall
└
```

Sorry for this little mess and thanks again! (Also a little typo fix in script itself)