### PR TITLE
Enable strict routing by default on Windows

### DIFF
--- a/include/database/SettingsRepo.h
+++ b/include/database/SettingsRepo.h
@@ -194,13 +194,15 @@ namespace Configs {
         // VPN
         bool fake_dns = false;
         bool enable_tun_routing = false;
-		bool vpn_strict_route = false;
 #ifdef Q_OS_MACOS
         QString vpn_implementation = "gvisor";
+        bool vpn_strict_route = false;
 #elif defined(Q_OS_WIN)
         QString vpn_implementation = WinVersion::IsBuildNumGreaterOrEqual(BuildNumber::Windows_10_1507) ? "system" : "gvisor";
+        bool vpn_strict_route = WinVersion::IsBuildNumGreaterOrEqual(BuildNumber::Windows_10_1507);
 #else
         QString vpn_implementation = "system";
+        bool vpn_strict_route = false;
 #endif
         int vpn_mtu = 1500;
         bool disable_private_range_bypass = false;

--- a/res/translations/ru_RU.ts
+++ b/res/translations/ru_RU.ts
@@ -3590,6 +3590,22 @@ Download them now?</source>
         <translation>Некорректное поведение устройства TUN</translation>
     </message>
     <message>
+        <source>Strict routing unavailable</source>
+        <translation>Строгая маршрутизация недоступна</translation>
+    </message>
+    <message>
+        <source>Windows could not enable strict routing. Open Tun Settings, disable Strict Route, and start the profile again.
+
+Disabling Strict Route may cause DNS leaks.
+
+Error: %1</source>
+        <translation>Windows не удалось включить строгую маршрутизацию. Откройте «Настройки режима TUN», отключите «Строгий маршрут» и снова запустите профиль.
+
+Отключение строгой маршрутизации может привести к утечкам DNS.
+
+Ошибка: %1</translation>
+    </message>
+    <message>
         <source>Reset</source>
         <translation>Сброс</translation>
     </message>

--- a/src/ui/mainwindow_rpc.cpp
+++ b/src/ui/mainwindow_rpc.cpp
@@ -941,6 +941,16 @@ void MainWindow::profile_start(int _id) {
             if (handleXrayGeoAssetError(error, ent->outbound->DisplayTypeAndName())) {
                 return false;
             }
+            if (error.contains("Fwpm", Qt::CaseInsensitive)) {
+                runOnUiThread([=, this] {
+                    MessageBoxWarning(
+                        tr("Strict routing unavailable"),
+                        tr("Windows could not enable strict routing. Open Tun Settings, "
+                           "disable Strict Route, and start the profile again.\n\n"
+                           "Disabling Strict Route may cause DNS leaks.\n\nError: %1").arg(error));
+                });
+                return false;
+            }
             if (error.contains("configure tun interface")) {
                 runOnUiThread([=, this] {
 


### PR DESCRIPTION
## Summary

Enable `Strict Route` by default on supported Windows versions.

Windows may send DNS queries through multiple network interfaces because of its multihomed DNS resolution behavior. Regular traffic can go through the TUN while some DNS requests still leave through the physical network adapter, revealing the local DNS resolver outside the tunnel.

With `Strict Route` enabled, sing-tun installs WFP rules that prevent port 53 traffic from bypassing the TUN. This behavior is also described in the [sing-box TUN documentation](https://sing-box.sagernet.org/configuration/inbound/tun/#strict_route).

Since this leak can happen silently, enabling `Strict Route` by default is the safer choice. Users who encounter WFP compatibility issues can still disable it manually in `Tun Settings`. Throne now explains where to find the option and warns about the possible DNS leak instead of changing it automatically.

A Russian translation for the warning is also included.

## Testing

- Clean Windows x64 build
- Checked the Russian translation with `lrelease`

Fixes #1678
Related to #1581