### PR TITLE
Fix mixed-core chain DNS bootstrap deadlock (#1684)

### DIFF
--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -652,31 +652,57 @@ namespace Configs {
         }
 
         if (dnsDeps->needDirectDnsRules) {
-            rules += QJsonObject{
-                    {"rule_set", dnsDeps->directRuleSets},
-                    {"domain", dnsDeps->directDomains},
-                    {"domain_suffix", dnsDeps->directSuffixes},
-                    {"domain_keyword", dnsDeps->directKeywords},
-                    {"domain_regex", dnsDeps->directRegexes},
-                    {"action", "route"},
-                    {"strategy", dataManager->settingsRepo->direct_dns_strategy},
-                    {"server", "dns-direct"},
-                };
+            // sing-box matches rule_set with AND against the other condition
+            // types (domain/suffix/keyword/regex are OR'd among themselves), so
+            // the rule_set needs its own rule — otherwise plain domains only
+            // match when they also match the rule_set, and proxy server domains
+            // would never reach dns-direct.
+            if (!dnsDeps->directRuleSets.isEmpty()) {
+                rules += QJsonObject{
+                        {"rule_set", dnsDeps->directRuleSets},
+                        {"action", "route"},
+                        {"strategy", dataManager->settingsRepo->direct_dns_strategy},
+                        {"server", "dns-direct"},
+                    };
+            }
+            if (!dnsDeps->directDomains.isEmpty() || !dnsDeps->directSuffixes.isEmpty() ||
+                !dnsDeps->directKeywords.isEmpty() || !dnsDeps->directRegexes.isEmpty()) {
+                rules += QJsonObject{
+                        {"domain", dnsDeps->directDomains},
+                        {"domain_suffix", dnsDeps->directSuffixes},
+                        {"domain_keyword", dnsDeps->directKeywords},
+                        {"domain_regex", dnsDeps->directRegexes},
+                        {"action", "route"},
+                        {"strategy", dataManager->settingsRepo->direct_dns_strategy},
+                        {"server", "dns-direct"},
+                    };
+            }
         }
 
         const bool useDirectFinalDNS = dataManager->settingsRepo->dns_final_out == "direct";
 
         if (dnsDeps->needProxyDnsRules && useDirectFinalDNS) {
-            rules += QJsonObject{
-                    {"rule_set", dnsDeps->proxyRuleSets},
-                    {"domain", dnsDeps->proxyDomains},
-                    {"domain_suffix", dnsDeps->proxySuffixes},
-                    {"domain_keyword", dnsDeps->proxyKeywords},
-                    {"domain_regex", dnsDeps->proxyRegexes},
-                    {"action", "route"},
-                    {"strategy", dataManager->settingsRepo->remote_dns_strategy},
-                    {"server", "dns-remote"},
-                };
+            // Same AND-vs-OR pitfall as the direct rules above.
+            if (!dnsDeps->proxyRuleSets.isEmpty()) {
+                rules += QJsonObject{
+                        {"rule_set", dnsDeps->proxyRuleSets},
+                        {"action", "route"},
+                        {"strategy", dataManager->settingsRepo->remote_dns_strategy},
+                        {"server", "dns-remote"},
+                    };
+            }
+            if (!dnsDeps->proxyDomains.isEmpty() || !dnsDeps->proxySuffixes.isEmpty() ||
+                !dnsDeps->proxyKeywords.isEmpty() || !dnsDeps->proxyRegexes.isEmpty()) {
+                rules += QJsonObject{
+                        {"domain", dnsDeps->proxyDomains},
+                        {"domain_suffix", dnsDeps->proxySuffixes},
+                        {"domain_keyword", dnsDeps->proxyKeywords},
+                        {"domain_regex", dnsDeps->proxyRegexes},
+                        {"action", "route"},
+                        {"strategy", dataManager->settingsRepo->remote_dns_strategy},
+                        {"server", "dns-remote"},
+                    };
+            }
         }
 
         // final rule: proxy

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -310,6 +310,7 @@ namespace Configs {
             {
                 preReqs->dnsDeps->directDomains << addr;
             }
+            if (!addrs.isEmpty()) preReqs->dnsDeps->needDirectDnsRules = true;
         }
 
         // Hijack

--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -214,6 +214,7 @@ namespace Configs {
                         ctx->error = "Chain hops in routing profile cannot use an extra core, a custom full config, or be of type chain";
                         return;
                     }
+                    if (usesXrayCore(hopEnt)) ctx->proxyUsesXray = true;
                     // Collect domains for DNS direct rules
                     if (auto addrs = getEntDomains({hopID}, ctx->error); !addrs.empty()) {
                         if (!ctx->error.isEmpty()) return;
@@ -230,6 +231,7 @@ namespace Configs {
                 suffix += chain->list.size();
             } else {
                 // Single-hop outbound (existing logic)
+                if (usesXrayCore(neededEnt)) ctx->proxyUsesXray = true;
                 if (auto entAddrs = getEntDomains({neededEnt->id}, ctx->error); !entAddrs.empty())
                 {
                     if (!ctx->error.isEmpty()) return;
@@ -304,6 +306,10 @@ namespace Configs {
             QList<int> groupEnts;
             if (auto frontEntID = group->front_proxy_id; frontEntID >= 0) groupEnts << frontEntID;
             if (auto landingEntID = group->landing_proxy_id; landingEntID >= 0) groupEnts << landingEntID;
+            for (const auto &id : groupEnts)
+            {
+                if (auto pe = Configs::dataManager->profilesRepo->GetProfile(id); pe != nullptr && usesXrayCore(pe)) ctx->proxyUsesXray = true;
+            }
             auto addrs = getEntDomains(groupEnts, ctx->error);
             if (!ctx->error.isEmpty()) return;
             for (const auto &addr: addrs)
@@ -584,6 +590,19 @@ namespace Configs {
                     {"action", "predefined"},
                     {"query_type", "AAAA"},
                     {"rcode", "NXDOMAIN"},
+                };
+        }
+
+        // Xray bridge hops resolve their own server domains through dns-in
+        // (wired via xray_outbound_dns_address). Those queries bootstrap the
+        // chain itself, so they must never be routed over the proxy — that
+        // deadlocks the chain before it can come up.
+        if (!ctx->forTest && ctx->proxyUsesXray) {
+            rules += QJsonObject{
+                    {"inbound", QJsonArray{"dns-in"}},
+                    {"action", "route"},
+                    {"strategy", dataManager->settingsRepo->direct_dns_strategy},
+                    {"server", "dns-direct"},
                 };
         }
 


### PR DESCRIPTION
   Fixes #1684.

   ## Problem

   A proxy chain mixing cores (e.g. a Shadowsocks/sing-box profile with an Xray-core VLESS-Reality profile as the group front proxy) fails to connect entirely. The Xray hop
 resolves its own server domain through sing-box's `dns-in` inbound (`xray_outbound_dns_address` = `127.0.0.1:5533`). That bootstrap query was routed to `dns-remote`, which has
 `detour: proxy` — i.e. it required the very chain it was trying to bootstrap. Deadlock: Xray never resolves its server, no traffic ever flows. Log signature:

   ```
   app/dns: UDP:127.0.0.1:5533 querying DNS for: <front-server-domain>
   dns: match[N] => route(dns-remote)
   dns: exchange failed for <front-server-domain>. IN A: context deadline exceeded
   transport/internet: failed to resolve ip > app/dns: record not found > common/retry: all retry attempts failed
   ```

   Same-core chains don't hit this because sing-box resolves outbound server addresses internally via `route.default_domain_resolver` (`dns-direct`), bypassing the DNS rule
 table.

   ## Root causes (three stacked defects, one commit each)

   1. **Missing `needDirectDnsRules` for group front/landing proxies** (`21ecea8e`)
      `CalculatePrerequisities` collected front/landing proxy server domains into `directDomains` but never set `needDirectDnsRules`, so when the main profile's server is an IP
 and no direct sites are configured, no `dns-direct` rule was emitted at all.

   2. **`rule_set` AND-masking in DNS rules** (`1eeda2ea`)
      The direct/proxy DNS rules combined `rule_set` + `domain`/`domain_suffix`/`domain_keyword`/`domain_regex` in a single default rule. sing-box ORs the domain-family
 conditions among themselves but ANDs `rule_set` against them (a non-matching rule set empties the rule's match-state set), so every plain domain on the list — including proxy
 server domains — was masked whenever a direct/proxy rule_set was configured. The rule_set now gets its own rule; guards prevent emitting a condition-less (match-all) rule.

   3. **No guaranteed direct path for Xray bootstrap DNS** (`0131ed5a`)
      Instead of relying solely on domain collection and rule semantics, route all `inbound = dns-in` queries to `dns-direct` whenever `proxyUsesXray`. Only the Xray outbound
 resolver talks to `dns-in`, and every such query bootstraps the chain, so they must never traverse the proxy. Also makes `proxyUsesXray` cover group front/landing proxies and
 routing-profile outbounds (previously only the main profile/chain), which additionally fixes the remote-DNS DoH upgrade decision for those layouts.

   ## Verification

   - Reproduced the reporter's setup: SS profile (IP server) + Xray VLESS-Reality front proxy (domain server), TUN mode. Before: no connectivity, `app/dns: record not found`
 loop. After: chain comes up; log shows `dns: match => route(dns-direct)` for the front server domain and connectivity works.
   - Exported sing-box config now contains `{"inbound": ["dns-in"], "server": "dns-direct"}` and the server domain in a `dns-direct` rule.
   - Full CI build matrix passes.

   ## Note for reviewers

   While testing I also noticed the core prints the **full configs (with credentials)** via `Start:`/`Start Xray:` log lines whenever the core process was launched with log level
 `debug` (`server.go` `if debug` block, env captured at process start — it keeps dumping even after switching back to `warn`). Pre-existing, unrelated to this PR; worth a
 separate issue.