### PR TITLE
fix: use HighlightedText for selected active config row on dark themes

### DIFF
--- a/src/ui/utils/ProfilesTableView.cpp
+++ b/src/ui/utils/ProfilesTableView.cpp
@@ -7,6 +7,20 @@
 #include <QHeaderView>
 #include <QKeyEvent>
 #include <QMimeData>
+#include <QStyledItemDelegate>
+
+class SelectionAwareDelegate : public QStyledItemDelegate {
+public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+protected:
+    void initStyleOption(QStyleOptionViewItem *option, const QModelIndex &index) const override {
+        QStyledItemDelegate::initStyleOption(option, index);
+        if (option->state & QStyle::State_Selected) {
+            option->palette.setBrush(QPalette::Text, option->palette.highlightedText());
+        }
+    }
+};
 
 ProfilesTableView::ProfilesTableView(QWidget *parent)
     : QTableView(parent) {
@@ -21,6 +35,7 @@ ProfilesTableView::ProfilesTableView(QWidget *parent)
     setVerticalHeader(m_verticalHeader);
     m_filterHeader = new ProfilesTableFilterHeader(this);
     setHorizontalHeader(m_filterHeader);
+    setItemDelegate(new SelectionAwareDelegate(this));
 }
 
 void ProfilesTableView::setModel(QAbstractItemModel *model) {


### PR DESCRIPTION
Fixes #1672

On dark themes (BlackSoft, QDarkStyle), the active/running config row is painted with `QPalette::Link` as its text color. When that row is selected, Qt still uses this custom foreground on top of the dark selection highlight background, making the text unreadable (blue-on-blue).

This adds a `SelectionAwareDelegate` to `ProfilesTableView` that resets the text brush to `QPalette::HighlightedText` for selected cells, so Qt's default selection text color takes precedence over any model-supplied foreground.

- Unselected running row: still shows the link-color text (unchanged)
- Selected running row: uses `HighlightedText` — readable on all themes
- All other rows: unaffected