### PR TITLE
 Fix WireGuard route-rule chains by binding generated route endpoints to TUN

### DIFF
--- a/src/configs/generate.cpp
+++ b/src/configs/generate.cpp
@@ -990,6 +990,18 @@ namespace Configs {
             object["tag"] = tag;
             if (!nextTag.isEmpty() && link) object["detour"] = nextTag;
             if (warpWrap && idx == 0) object["detour"] = "warp-bypass";
+            // sing-box 1.13.x does not reliably route TCP/UDP from a regular
+            // route rule into a WireGuard endpoint. In TUN mode, match the
+            // manual workaround users currently need for route-target chains:
+            // bind the generated route endpoint to Throne's TUN interface,
+            // while preserving any explicit bind_interface advanced setting.
+            if (prefix == "route" && idx == 0 && ctx->tunEnabled
+                && object["type"].toString() == "wireguard"
+                && !object.contains("bind_interface"))
+            {
+                const auto tunName = genTunName();
+                if (!tunName.isEmpty()) object["bind_interface"] = tunName;
+            }
             if (ent->outbound->IsEndpoint())
             {
                 ctx->endpoints.append(object);


### PR DESCRIPTION
Throne treated generated WireGuard endpoint tags as valid route-rule targets in the same way as normal outbounds. On sing-box 1.13.x, route rules targeting WireGuard endpoints do not reliably carry TCP/UDP route-profile traffic. This broke route-profile chains whose first generated hop was WireGuard/AmneziaWG. Applying `bind_interface = throne-tun` to those generated WireGuard route endpoints to restores connectivity.

This should be treated as a sing-box 1.13.x compatibility shim.
When Throne upgrades to sing-box 1.14+, re-check this path. sing-box 1.14 documents broader TCP/UDP L3 forwarding support to WireGuard/Tailscale endpoints, so this auto-bind may become unnecessary or should be gated by core version.