### PR TITLE
Harden bundled quirc QR decoder against a crafted-image hang (and a NULL memcpy)

### DIFF
--- a/3rdparty/quirc/identify.c
+++ b/3rdparty/quirc/identify.c
@@ -605,8 +605,15 @@ static void find_alignment_pattern(struct quirc *q, int index)
 	/* Spiral outwards from the estimate point until we find something
 	 * roughly the right size. Don't look too far from the estimate
 	 * point.
+	 *
+	 * A degenerate perspective transform (near-zero denominator) can make
+	 * size_estimate enormous, which would spin this spiral for hundreds of
+	 * millions of iterations on a tiny image (denial of service on a crafted
+	 * QR). The alignment pattern must lie within the image, so also cap the
+	 * search radius at the image size.
 	 */
-	while (step_size * step_size < size_estimate * 100) {
+	int max_step = (q->w > q->h ? q->w : q->h) + 1;
+	while (step_size * step_size < size_estimate * 100 && step_size <= max_step) {
 		static const int dx_map[] = {1, 0, -1, 0};
 		static const int dy_map[] = {0, -1, 0, 1};
 		int i;

--- a/3rdparty/quirc/quirc.c
+++ b/3rdparty/quirc/quirc.c
@@ -81,7 +81,8 @@ int quirc_resize(struct quirc *q, int w, int h)
 	 * old buffer when the new size is greater and (b) to write beyond the
 	 * new buffer when the new size is smaller, hence the min computation.
 	 */
-	(void)memcpy(image, q->image, min);
+	if (min)
+		(void)memcpy(image, q->image, min);
 
 	/* alloc a new buffer for q->pixels if needed */
 	if (!QUIRC_PIXEL_ALIAS_IMAGE) {


### PR DESCRIPTION
## Harden the bundled quirc QR decoder against a crafted-image hang (and a NULL memcpy)

Two fixes to the vendored `3rdparty/quirc` QR decoder, both reachable when a user scans or opens
a QR **image** to import a link (`QrDecoder::decode` → quirc, called synchronously on the UI
thread from `mainwindow_profiles.cpp`). Found by fuzzing quirc with libFuzzer + ASan/UBSan, using
real QR codes (generated via the bundled `qrcodegen`) as the seed corpus so the decoder is
actually exercised end to end.

**1. Denial of service: unbounded alignment-pattern spiral (the important one).**
`find_alignment_pattern()` in `identify.c` spirals outward while
`step_size*step_size < size_estimate*100`. `size_estimate` is derived from coordinates produced by
the perspective transform; a degenerate transform (near-zero denominator) makes those coordinates
huge, so `size_estimate` becomes enormous and the loop runs for hundreds of millions of
iterations. A **246×246** image (about the size of a real screenshot QR) makes `quirc_end()` run
for **over 90 seconds** on ~28 MB of RAM — a pure CPU hang. Because decoding runs on the UI thread,
a crafted image freezes the client ("scan this QR to import my config"). The alignment pattern must
lie within the image, so this caps the spiral radius at the image size. Verified: the 90s+ hang
drops to ~13 ms and real QR codes (vmess/vless/…) still decode.

**2. Undefined behaviour: `memcpy(dst, NULL, 0)` on first resize.**
On the first `quirc_resize()`, `q->image` is NULL and `q->w == q->h == 0`, so `min == 0` and the
copy becomes `memcpy(image, NULL, 0)` — UB (memcpy's source is declared `nonnull`), which UBSan
flags on every scan. Guarded with `if (min)`.

Notes:
- These patch the vendored copy of quirc; the same issues likely exist upstream (dlbeer/quirc) and
  ideally the fixes would be sent there too — this is the immediate fix for Throne.
- No memory-corruption was found in quirc (ASan campaign: 0 crashes; all findings were the DoS-hang
  class above).
- The full Qt app was not rebuilt in my environment (no qt6 devel headers), but the quirc module
  builds standalone and was verified to still decode real QR codes after the fixes.

Minimal reproducer for the hang and a per-issue write-up are available on request.
