### PR TITLE
Improve tab navigation in profile editor dialogs

### DIFF
--- a/include/ui/profile/dialog_edit_profile.h
+++ b/include/ui/profile/dialog_edit_profile.h
@@ -36,6 +36,8 @@ private:
 
     QWidget *innerWidget{};
     ProfileEditor *innerEditor{};
+    QList<QWidget *> outerTabOrder;
+    qsizetype innerTabOrderIndex{-1};
 
     QString type;
     int groupId;

--- a/include/ui/profile/dialog_edit_profile.ui
+++ b/include/ui/profile/dialog_edit_profile.ui
@@ -1525,6 +1525,7 @@
   <tabstop>address</tabstop>
   <tabstop>port</tabstop>
   <tabstop>advanced_button</tabstop>
+  <tabstop>fake</tabstop>
   <tabstop>xray_network</tabstop>
   <tabstop>xray_security</tabstop>
   <tabstop>xray_mux</tabstop>

--- a/include/ui/profile/dialog_edit_profile.ui
+++ b/include/ui/profile/dialog_edit_profile.ui
@@ -1133,369 +1133,369 @@
                </property>
                <layout class="QVBoxLayout" name="verticalLayout_xray_xhttp">
                 <item>
-             <widget class="QGroupBox" name="xray_xhttp_common_box">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Common</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_xray_xhttp_common">
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_21">
-                 <property name="text">
-                  <string>Mode</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QComboBox" name="xray_mode"/>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="label_23">
-                 <property name="text">
-                  <string>X Padding Bytes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <widget class="QLineEdit" name="xray_xpaddingbytes"/>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="xray_serverMaxHeaderBytes_l">
-                 <property name="text">
-                  <string>Server Max Header Bytes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLineEdit" name="xray_serverMaxHeaderBytes"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="xray_xhttp_padding_box">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Padding Obfuscation</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_xray_xhttp_padding">
-               <item row="0" column="0" colspan="4">
-                <widget class="QCheckBox" name="xray_xpadding_obfs_mode">
-                 <property name="text">
-                  <string>xPaddingObfsMode</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_xpadding_method">
-                 <property name="text">
-                  <string>xPaddingMethod</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QComboBox" name="xray_xpadding_method"/>
-               </item>
-               <item row="1" column="2">
-                <widget class="QLabel" name="label_xpadding_placement">
-                 <property name="text">
-                  <string>xPaddingPlacement</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QComboBox" name="xray_xpadding_placement"/>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_xpadding_key">
-                 <property name="text">
-                  <string>xPaddingKey</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QLineEdit" name="xray_xpadding_key"/>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLabel" name="label_xpadding_header">
-                 <property name="text">
-                  <string>xPaddingHeader</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QLineEdit" name="xray_xpadding_header"/>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="xray_xhttp_packet_box">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Upload / Stream Tuning</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_xray_xhttp_packet">
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_24">
-                 <property name="text">
-                  <string>scMaxEachPostBytes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLineEdit" name="xray_scMaxEachPostBytes"/>
-               </item>
-               <item row="1" column="2">
-                <widget class="QLabel" name="label_25">
-                 <property name="text">
-                  <string>scMinPostsIntervalMs</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QLineEdit" name="xray_scMinPostsIntervalMs"/>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="xray_scMaxBufferedPosts_l">
-                 <property name="text">
-                  <string>scMaxBufferedPosts</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QLineEdit" name="xray_scMaxBufferedPosts"/>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLabel" name="xray_uplink_http_method_l">
-                 <property name="text">
-                  <string>uplinkHTTPMethod</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QComboBox" name="xray_uplink_http_method"/>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="xray_uplink_data_placement_l">
-                 <property name="text">
-                  <string>uplinkDataPlacement</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="1">
-                <widget class="QComboBox" name="xray_uplink_data_placement"/>
-               </item>
-               <item row="3" column="2">
-                <widget class="QLabel" name="xray_uplink_data_key_l">
-                 <property name="text">
-                  <string>uplinkDataKey</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="3">
-                <widget class="QLineEdit" name="xray_uplink_data_key"/>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="xray_uplink_chunk_size_l">
-                 <property name="text">
-                  <string>uplinkChunkSize</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="4" column="1">
-                <widget class="QLineEdit" name="xray_uplink_chunk_size"/>
-               </item>
-               <item row="0" column="0" colspan="2">
-                <widget class="QCheckBox" name="xray_no_grpc">
-                 <property name="text">
-                  <string>noGRPCHeader</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2" colspan="2">
-                <widget class="QCheckBox" name="xray_no_sse">
-                 <property name="text">
-                  <string>noSSEHeader</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="xray_scStreamUpServerSecs_l">
-                 <property name="text">
-                  <string>scStreamUpServerSecs</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="1">
-                <widget class="QLineEdit" name="xray_scStreamUpServerSecs"/>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="xray_session_placement_l">
-                 <property name="text">
-                  <string>sessionPlacement</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="1">
-                <widget class="QComboBox" name="xray_session_placement"/>
-               </item>
-               <item row="6" column="2">
-                <widget class="QLabel" name="xray_session_key_l">
-                 <property name="text">
-                  <string>sessionKey</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="3">
-                <widget class="QLineEdit" name="xray_session_key"/>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="xray_session_id_table_l">
-                 <property name="text">
-                  <string>sessionIDTable</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="1">
-                <widget class="QLineEdit" name="xray_session_id_table"/>
-               </item>
-               <item row="7" column="2">
-                <widget class="QLabel" name="xray_session_id_length_l">
-                 <property name="text">
-                  <string>sessionIDLength</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="3">
-                <widget class="QLineEdit" name="xray_session_id_length"/>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="xray_seq_placement_l">
-                 <property name="text">
-                  <string>seqPlacement</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="1">
-                <widget class="QComboBox" name="xray_seq_placement"/>
-               </item>
-               <item row="8" column="2">
-                <widget class="QLabel" name="xray_seq_key_l">
-                 <property name="text">
-                  <string>seqKey</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="3">
-                <widget class="QLineEdit" name="xray_seq_key"/>
-               </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_32">
-                 <property name="text">
-                  <string>Download Settings</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="1" colspan="3">
-                <widget class="QPushButton" name="xray_downloadsettings_edit">
-                 <property name="text">
-                  <string>Edit</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="xray_xhttp_xmux_box">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="title">
-               <string>Xmux</string>
-              </property>
-              <layout class="QGridLayout" name="gridLayout_xray_xhttp_xmux">
-               <item row="0" column="0">
-                <widget class="QLabel" name="label_26">
-                 <property name="text">
-                  <string>maxConcurrency</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QLineEdit" name="xray_max_concurrency"/>
-               </item>
-               <item row="0" column="2">
-                <widget class="QLabel" name="label_31">
-                 <property name="text">
-                  <string>maxConnections</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="3">
-                <widget class="QLineEdit" name="xray_max_connections"/>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_27">
-                 <property name="text">
-                  <string>hMaxRequestTimes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QLineEdit" name="xray_hMaxRequestTimes"/>
-               </item>
-               <item row="1" column="2">
-                <widget class="QLabel" name="label_28">
-                 <property name="text">
-                  <string>hMaxReusableSecs</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <widget class="QLineEdit" name="xray_hMaxReusableSecs"/>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_29">
-                 <property name="text">
-                  <string>cMaxReuseTimes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="1">
-                <widget class="QLineEdit" name="xray_max_reuse_times"/>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLabel" name="label_30">
-                 <property name="text">
-                  <string>hKeepAlivePeriod</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="3">
-                <widget class="QLineEdit" name="xray_keep_alive_period"/>
-               </item>
-              </layout>
-             </widget>
+                 <widget class="QGroupBox" name="xray_xhttp_common_box">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="title">
+                   <string>Common</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_xray_xhttp_common">
+                   <item row="0" column="0">
+                    <widget class="QLabel" name="label_21">
+                     <property name="text">
+                      <string>Mode</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <widget class="QComboBox" name="xray_mode"/>
+                   </item>
+                   <item row="0" column="2">
+                    <widget class="QLabel" name="label_23">
+                     <property name="text">
+                      <string>X Padding Bytes</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="3">
+                    <widget class="QLineEdit" name="xray_xpaddingbytes"/>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="xray_serverMaxHeaderBytes_l">
+                     <property name="text">
+                      <string>Server Max Header Bytes</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QLineEdit" name="xray_serverMaxHeaderBytes"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="xray_xhttp_padding_box">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="title">
+                   <string>Padding Obfuscation</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_xray_xhttp_padding">
+                   <item row="0" column="0" colspan="4">
+                    <widget class="QCheckBox" name="xray_xpadding_obfs_mode">
+                     <property name="text">
+                      <string>xPaddingObfsMode</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_xpadding_method">
+                     <property name="text">
+                      <string>xPaddingMethod</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QComboBox" name="xray_xpadding_method"/>
+                   </item>
+                   <item row="1" column="2">
+                    <widget class="QLabel" name="label_xpadding_placement">
+                     <property name="text">
+                      <string>xPaddingPlacement</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="3">
+                    <widget class="QComboBox" name="xray_xpadding_placement"/>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QLabel" name="label_xpadding_key">
+                     <property name="text">
+                      <string>xPaddingKey</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QLineEdit" name="xray_xpadding_key"/>
+                   </item>
+                   <item row="2" column="2">
+                    <widget class="QLabel" name="label_xpadding_header">
+                     <property name="text">
+                      <string>xPaddingHeader</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="3">
+                    <widget class="QLineEdit" name="xray_xpadding_header"/>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="xray_xhttp_packet_box">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="title">
+                   <string>Upload / Stream Tuning</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_xray_xhttp_packet">
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_24">
+                     <property name="text">
+                      <string>scMaxEachPostBytes</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QLineEdit" name="xray_scMaxEachPostBytes"/>
+                   </item>
+                   <item row="1" column="2">
+                    <widget class="QLabel" name="label_25">
+                     <property name="text">
+                      <string>scMinPostsIntervalMs</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="3">
+                    <widget class="QLineEdit" name="xray_scMinPostsIntervalMs"/>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QLabel" name="xray_scMaxBufferedPosts_l">
+                     <property name="text">
+                      <string>scMaxBufferedPosts</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QLineEdit" name="xray_scMaxBufferedPosts"/>
+                   </item>
+                   <item row="2" column="2">
+                    <widget class="QLabel" name="xray_uplink_http_method_l">
+                     <property name="text">
+                      <string>uplinkHTTPMethod</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="3">
+                    <widget class="QComboBox" name="xray_uplink_http_method"/>
+                   </item>
+                   <item row="3" column="0">
+                    <widget class="QLabel" name="xray_uplink_data_placement_l">
+                     <property name="text">
+                      <string>uplinkDataPlacement</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QComboBox" name="xray_uplink_data_placement"/>
+                   </item>
+                   <item row="3" column="2">
+                    <widget class="QLabel" name="xray_uplink_data_key_l">
+                     <property name="text">
+                      <string>uplinkDataKey</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="3">
+                    <widget class="QLineEdit" name="xray_uplink_data_key"/>
+                   </item>
+                   <item row="4" column="0">
+                    <widget class="QLabel" name="xray_uplink_chunk_size_l">
+                     <property name="text">
+                      <string>uplinkChunkSize</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="4" column="1">
+                    <widget class="QLineEdit" name="xray_uplink_chunk_size"/>
+                   </item>
+                   <item row="0" column="0" colspan="2">
+                    <widget class="QCheckBox" name="xray_no_grpc">
+                     <property name="text">
+                      <string>noGRPCHeader</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="2" colspan="2">
+                    <widget class="QCheckBox" name="xray_no_sse">
+                     <property name="text">
+                      <string>noSSEHeader</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="0">
+                    <widget class="QLabel" name="xray_scStreamUpServerSecs_l">
+                     <property name="text">
+                      <string>scStreamUpServerSecs</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="5" column="1">
+                    <widget class="QLineEdit" name="xray_scStreamUpServerSecs"/>
+                   </item>
+                   <item row="6" column="0">
+                    <widget class="QLabel" name="xray_session_placement_l">
+                     <property name="text">
+                      <string>sessionPlacement</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="1">
+                    <widget class="QComboBox" name="xray_session_placement"/>
+                   </item>
+                   <item row="6" column="2">
+                    <widget class="QLabel" name="xray_session_key_l">
+                     <property name="text">
+                      <string>sessionKey</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="6" column="3">
+                    <widget class="QLineEdit" name="xray_session_key"/>
+                   </item>
+                   <item row="7" column="0">
+                    <widget class="QLabel" name="xray_session_id_table_l">
+                     <property name="text">
+                      <string>sessionIDTable</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="7" column="1">
+                    <widget class="QLineEdit" name="xray_session_id_table"/>
+                   </item>
+                   <item row="7" column="2">
+                    <widget class="QLabel" name="xray_session_id_length_l">
+                     <property name="text">
+                      <string>sessionIDLength</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="7" column="3">
+                    <widget class="QLineEdit" name="xray_session_id_length"/>
+                   </item>
+                   <item row="8" column="0">
+                    <widget class="QLabel" name="xray_seq_placement_l">
+                     <property name="text">
+                      <string>seqPlacement</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="8" column="1">
+                    <widget class="QComboBox" name="xray_seq_placement"/>
+                   </item>
+                   <item row="8" column="2">
+                    <widget class="QLabel" name="xray_seq_key_l">
+                     <property name="text">
+                      <string>seqKey</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="8" column="3">
+                    <widget class="QLineEdit" name="xray_seq_key"/>
+                   </item>
+                   <item row="9" column="0">
+                    <widget class="QLabel" name="label_32">
+                     <property name="text">
+                      <string>Download Settings</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="9" column="1" colspan="3">
+                    <widget class="QPushButton" name="xray_downloadsettings_edit">
+                     <property name="text">
+                      <string>Edit</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="xray_xhttp_xmux_box">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="title">
+                   <string>Xmux</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_xray_xhttp_xmux">
+                   <item row="0" column="0">
+                    <widget class="QLabel" name="label_26">
+                     <property name="text">
+                      <string>maxConcurrency</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <widget class="QLineEdit" name="xray_max_concurrency"/>
+                   </item>
+                   <item row="0" column="2">
+                    <widget class="QLabel" name="label_31">
+                     <property name="text">
+                      <string>maxConnections</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="3">
+                    <widget class="QLineEdit" name="xray_max_connections"/>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_27">
+                     <property name="text">
+                      <string>hMaxRequestTimes</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QLineEdit" name="xray_hMaxRequestTimes"/>
+                   </item>
+                   <item row="1" column="2">
+                    <widget class="QLabel" name="label_28">
+                     <property name="text">
+                      <string>hMaxReusableSecs</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="3">
+                    <widget class="QLineEdit" name="xray_hMaxReusableSecs"/>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QLabel" name="label_29">
+                     <property name="text">
+                      <string>cMaxReuseTimes</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
+                    <widget class="QLineEdit" name="xray_max_reuse_times"/>
+                   </item>
+                   <item row="2" column="2">
+                    <widget class="QLabel" name="label_30">
+                     <property name="text">
+                      <string>hKeepAlivePeriod</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="3">
+                    <widget class="QLineEdit" name="xray_keep_alive_period"/>
+                   </item>
+                  </layout>
+                 </widget>
                 </item>
                </layout>
               </widget>
@@ -1524,20 +1524,79 @@
   <tabstop>name</tabstop>
   <tabstop>address</tabstop>
   <tabstop>port</tabstop>
+  <tabstop>advanced_button</tabstop>
+  <tabstop>xray_network</tabstop>
+  <tabstop>xray_security</tabstop>
+  <tabstop>xray_mux</tabstop>
   <tabstop>network</tabstop>
   <tabstop>security</tabstop>
   <tabstop>multiplex</tabstop>
+  <tabstop>brutal_enable</tabstop>
+  <tabstop>brutal_d_speed</tabstop>
+  <tabstop>brutal_u_speed</tabstop>
+  <tabstop>headers</tabstop>
+  <tabstop>method</tabstop>
   <tabstop>path</tabstop>
   <tabstop>host</tabstop>
   <tabstop>ws_early_data_length</tabstop>
   <tabstop>ws_early_data_name</tabstop>
+  <tabstop>service_name</tabstop>
   <tabstop>insecure</tabstop>
   <tabstop>certificate_edit</tabstop>
   <tabstop>sni</tabstop>
   <tabstop>alpn</tabstop>
+  <tabstop>fragment</tabstop>
+  <tabstop>tls_frag_fall_delay</tabstop>
+  <tabstop>tls_rec_frag</tabstop>
+  <tabstop>tls_tricks</tabstop>
   <tabstop>utlsFingerprint</tabstop>
   <tabstop>reality_pbk</tabstop>
   <tabstop>reality_sid</tabstop>
+  <tabstop>xray_sni</tabstop>
+  <tabstop>xray_fp</tabstop>
+  <tabstop>xray_alpn</tabstop>
+  <tabstop>xray_pinned_peer_cert_sha256</tabstop>
+  <tabstop>xray_verify_peer_cert_by_name</tabstop>
+  <tabstop>xray_reality_pbk</tabstop>
+  <tabstop>xray_reality_sid</tabstop>
+  <tabstop>xray_reality_spiderx</tabstop>
+  <tabstop>xray_network_scroll</tabstop>
+  <tabstop>xray_host</tabstop>
+  <tabstop>xray_path</tabstop>
+  <tabstop>xray_ed_length</tabstop>
+  <tabstop>xray_multi_mode</tabstop>
+  <tabstop>xray_headers</tabstop>
+  <tabstop>xray_mode</tabstop>
+  <tabstop>xray_xpaddingbytes</tabstop>
+  <tabstop>xray_serverMaxHeaderBytes</tabstop>
+  <tabstop>xray_xpadding_obfs_mode</tabstop>
+  <tabstop>xray_xpadding_method</tabstop>
+  <tabstop>xray_xpadding_placement</tabstop>
+  <tabstop>xray_xpadding_key</tabstop>
+  <tabstop>xray_xpadding_header</tabstop>
+  <tabstop>xray_no_grpc</tabstop>
+  <tabstop>xray_no_sse</tabstop>
+  <tabstop>xray_scMaxEachPostBytes</tabstop>
+  <tabstop>xray_scMinPostsIntervalMs</tabstop>
+  <tabstop>xray_scMaxBufferedPosts</tabstop>
+  <tabstop>xray_uplink_http_method</tabstop>
+  <tabstop>xray_uplink_data_placement</tabstop>
+  <tabstop>xray_uplink_data_key</tabstop>
+  <tabstop>xray_uplink_chunk_size</tabstop>
+  <tabstop>xray_scStreamUpServerSecs</tabstop>
+  <tabstop>xray_session_placement</tabstop>
+  <tabstop>xray_session_key</tabstop>
+  <tabstop>xray_session_id_table</tabstop>
+  <tabstop>xray_session_id_length</tabstop>
+  <tabstop>xray_seq_placement</tabstop>
+  <tabstop>xray_seq_key</tabstop>
+  <tabstop>xray_downloadsettings_edit</tabstop>
+  <tabstop>xray_max_concurrency</tabstop>
+  <tabstop>xray_max_connections</tabstop>
+  <tabstop>xray_hMaxRequestTimes</tabstop>
+  <tabstop>xray_hMaxReusableSecs</tabstop>
+  <tabstop>xray_max_reuse_times</tabstop>
+  <tabstop>xray_keep_alive_period</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/include/ui/profile/edit_advanced.ui
+++ b/include/ui/profile/edit_advanced.ui
@@ -227,6 +227,25 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>reuse_addr</tabstop>
+  <tabstop>tcp_fast_open</tabstop>
+  <tabstop>udp_fragment</tabstop>
+  <tabstop>tcp_multipath</tabstop>
+  <tabstop>connect_timeout</tabstop>
+  <tabstop>bind_interface</tabstop>
+  <tabstop>inet4_bind_address</tabstop>
+  <tabstop>inet6_bind_address</tabstop>
+  <tabstop>disable_sni</tabstop>
+  <tabstop>min_version</tabstop>
+  <tabstop>max_version</tabstop>
+  <tabstop>enable_ech</tabstop>
+  <tabstop>ech_server_name</tabstop>
+  <tabstop>ech_config</tabstop>
+  <tabstop>cert_sha256</tabstop>
+  <tabstop>client_cert</tabstop>
+  <tabstop>client_key</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/include/ui/profile/edit_autoselector.ui
+++ b/include/ui/profile/edit_autoselector.ui
@@ -632,6 +632,32 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>group</tabstop>
+  <tabstop>name_filter</tabstop>
+  <tabstop>balance</tabstop>
+  <tabstop>pinned_clear</tabstop>
+  <tabstop>advanced_toggle</tabstop>
+  <tabstop>country_filter</tabstop>
+  <tabstop>build_limit</tabstop>
+  <tabstop>pool_cap</tabstop>
+  <tabstop>result_validity</tabstop>
+  <tabstop>exclude_unavailable</tabstop>
+  <tabstop>expected</tabstop>
+  <tabstop>active_size</tabstop>
+  <tabstop>interval</tabstop>
+  <tabstop>bench_interval</tabstop>
+  <tabstop>watch_interval</tabstop>
+  <tabstop>sampling</tabstop>
+  <tabstop>tolerance</tabstop>
+  <tabstop>max_rtt</tabstop>
+  <tabstop>dial_retries</tabstop>
+  <tabstop>interrupt_on_switch</tabstop>
+  <tabstop>balance_mode</tabstop>
+  <tabstop>balance_interval</tabstop>
+  <tabstop>test_url</tabstop>
+  <tabstop>connectivity_url</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_extra_core.ui
+++ b/include/ui/profile/edit_extra_core.ui
@@ -153,6 +153,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>socks_address</tabstop>
+  <tabstop>socks_port</tabstop>
+  <tabstop>path_combo</tabstop>
+  <tabstop>path_button</tabstop>
+  <tabstop>no_logs</tabstop>
+  <tabstop>args</tabstop>
+  <tabstop>config</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_hysteria.ui
+++ b/include/ui/profile/edit_hysteria.ui
@@ -160,6 +160,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>protocol_version</tabstop>
+  <tabstop>server_ports</tabstop>
+  <tabstop>hop_interval</tabstop>
+  <tabstop>up_mbps</tabstop>
+  <tabstop>down_mbps</tabstop>
+  <tabstop>obfs</tabstop>
+  <tabstop>auth_type</tabstop>
+  <tabstop>auth</tabstop>
+  <tabstop>recv_window_conn</tabstop>
+  <tabstop>recv_window</tabstop>
+  <tabstop>disable_mtu_discovery</tabstop>
+  <tabstop>password</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_mieru.ui
+++ b/include/ui/profile/edit_mieru.ui
@@ -90,6 +90,10 @@
  <tabstops>
   <tabstop>username</tabstop>
   <tabstop>password</tabstop>
+  <tabstop>transport</tabstop>
+  <tabstop>multiplexing</tabstop>
+  <tabstop>traffic_pattern</tabstop>
+  <tabstop>server_ports</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/include/ui/profile/edit_naive.ui
+++ b/include/ui/profile/edit_naive.ui
@@ -81,6 +81,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>username</tabstop>
+  <tabstop>password</tabstop>
+  <tabstop>uot</tabstop>
+  <tabstop>quic</tabstop>
+  <tabstop>congestion_control</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_socks.ui
+++ b/include/ui/profile/edit_socks.ui
@@ -57,6 +57,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>version</tabstop>
+  <tabstop>username</tabstop>
+  <tabstop>password</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_ssh.ui
+++ b/include/ui/profile/edit_ssh.ui
@@ -109,6 +109,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>user</tabstop>
+  <tabstop>password</tabstop>
+  <tabstop>private_key</tabstop>
+  <tabstop>private_key_path</tabstop>
+  <tabstop>choose_pk</tabstop>
+  <tabstop>private_key_pass</tabstop>
+  <tabstop>host_key</tabstop>
+  <tabstop>host_key_algs</tabstop>
+  <tabstop>client_version</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_tailscale.ui
+++ b/include/ui/profile/edit_tailscale.ui
@@ -117,6 +117,19 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>state_dir</tabstop>
+  <tabstop>auth_key</tabstop>
+  <tabstop>control_plane</tabstop>
+  <tabstop>hostname</tabstop>
+  <tabstop>exit_node</tabstop>
+  <tabstop>advertise_routes</tabstop>
+  <tabstop>global_dns</tabstop>
+  <tabstop>ephemeral</tabstop>
+  <tabstop>accept_route</tabstop>
+  <tabstop>exit_node_lan_access</tabstop>
+  <tabstop>advertise_exit_node</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_trusttunnel.ui
+++ b/include/ui/profile/edit_trusttunnel.ui
@@ -91,6 +91,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>username</tabstop>
+  <tabstop>password</tabstop>
+  <tabstop>health_check</tabstop>
+  <tabstop>quic</tabstop>
+  <tabstop>congestion_control</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_tuic.ui
+++ b/include/ui/profile/edit_tuic.ui
@@ -107,6 +107,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>uuid</tabstop>
+  <tabstop>password</tabstop>
+  <tabstop>congestion_control</tabstop>
+  <tabstop>udp_relay_mode</tabstop>
+  <tabstop>udp_over_stream</tabstop>
+  <tabstop>zero_rtt</tabstop>
+  <tabstop>heartbeat</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_vless.ui
+++ b/include/ui/profile/edit_vless.ui
@@ -53,6 +53,11 @@
    <header>include/ui/utils/MyLineEdit.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>uuid</tabstop>
+  <tabstop>flow</tabstop>
+  <tabstop>packet_encoding</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/include/ui/profile/edit_vmess.ui
+++ b/include/ui/profile/edit_vmess.ui
@@ -127,6 +127,7 @@
   <tabstop>uuid</tabstop>
   <tabstop>aid</tabstop>
   <tabstop>uuidgen</tabstop>
+  <tabstop>packet_encoding</tabstop>
   <tabstop>security</tabstop>
  </tabstops>
  <resources/>

--- a/include/ui/profile/edit_wireguard.ui
+++ b/include/ui/profile/edit_wireguard.ui
@@ -399,6 +399,42 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>private_key</tabstop>
+  <tabstop>public_key</tabstop>
+  <tabstop>preshared_key</tabstop>
+  <tabstop>reserved</tabstop>
+  <tabstop>persistent_keepalive</tabstop>
+  <tabstop>local_addr</tabstop>
+  <tabstop>mtu</tabstop>
+  <tabstop>workers</tabstop>
+  <tabstop>sys_ifc</tabstop>
+  <tabstop>warp_autogen</tabstop>
+  <tabstop>enable_amnezia</tabstop>
+  <tabstop>jc</tabstop>
+  <tabstop>jmin</tabstop>
+  <tabstop>jmax</tabstop>
+  <tabstop>s1</tabstop>
+  <tabstop>s2</tabstop>
+  <tabstop>s3</tabstop>
+  <tabstop>s4</tabstop>
+  <tabstop>h1</tabstop>
+  <tabstop>h2</tabstop>
+  <tabstop>h3</tabstop>
+  <tabstop>h4</tabstop>
+  <tabstop>i1</tabstop>
+  <tabstop>i2</tabstop>
+  <tabstop>i3</tabstop>
+  <tabstop>i4</tabstop>
+  <tabstop>i5</tabstop>
+  <tabstop>header_protection_key</tabstop>
+  <tabstop>content_padding_addition</tabstop>
+  <tabstop>rekey_after_time</tabstop>
+  <tabstop>rekey_timeout</tabstop>
+  <tabstop>reject_after_time</tabstop>
+  <tabstop>keepalive_timeout</tabstop>
+  <tabstop>max_handshake_attempts</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/profile/dialog_edit_profile.cpp
+++ b/src/ui/profile/dialog_edit_profile.cpp
@@ -20,6 +20,7 @@
 
 #include <QInputDialog>
 #include <QLabel>
+#include <QSet>
 
 #include "include/configs/common/TLS.h"
 #include "include/configs/common/utils.h"
@@ -44,6 +45,50 @@
 
 namespace {
 constexpr int kXrayXHTTPNetworkMinWidth = 760;
+
+QWidget *effectiveFocusWidget(QWidget *widget) {
+    QSet<QWidget *> visited;
+    while (widget && widget->focusProxy() && !visited.contains(widget)) {
+        visited.insert(widget);
+        widget = widget->focusProxy();
+    }
+    return widget;
+}
+
+QList<QWidget *> collectTabOrder(QWidget *window, const QWidget *subtree = nullptr,
+                                 const QWidget *marker = nullptr) {
+    if (!window) return {};
+
+    QList<QWidget *> tabOrder;
+    QSet<QWidget *> visited;
+    auto *current = window;
+    while (true) {
+        auto *next = current->nextInFocusChain();
+        if (!next || next == window || visited.contains(next)) break;
+        visited.insert(next);
+        current = next;
+
+        if (subtree && current != subtree && !subtree->isAncestorOf(current)) continue;
+
+        const bool isMarker = current == marker;
+        if (!isMarker && !(current->focusPolicy() & Qt::TabFocus)) continue;
+
+        auto *focusWidget = isMarker ? current : effectiveFocusWidget(current);
+        if (!focusWidget || tabOrder.contains(focusWidget)) continue;
+        if (subtree && focusWidget != subtree && !subtree->isAncestorOf(focusWidget)) continue;
+        tabOrder.append(focusWidget);
+    }
+
+    return tabOrder;
+}
+
+void rebuildTabOrder(const QList<QWidget *> &tabOrder) {
+    if (tabOrder.size() < 2) return;
+
+    for (qsizetype i = 1; i < tabOrder.size(); ++i) {
+        QWidget::setTabOrder(tabOrder.at(i - 1), tabOrder.at(i));
+    }
+}
 }
 
 void DialogEditProfile::queueRefreshDialogLayout() {
@@ -68,6 +113,12 @@ DialogEditProfile::DialogEditProfile(const QString &_type, int profileOrGroupId,
     : QDialog(parent), ui(new Ui::DialogEditProfile) {
     // setup UI
     ui->setupUi(this);
+
+    // Save current tab order and the insertion point for innerWidget
+    outerTabOrder = collectTabOrder(this, nullptr, ui->fake);
+    innerTabOrderIndex = outerTabOrder.indexOf(ui->fake);
+    if (innerTabOrderIndex >= 0) outerTabOrder.removeAt(innerTabOrderIndex);
+
     auto setXrayXHTTPNetworkVisible = [=,this](bool visible) {
         ui->xray_network_scroll->setMinimumWidth(visible ? kXrayXHTTPNetworkMinWidth : 0);
         ui->xray_xhttp_box->setVisible(visible);
@@ -580,6 +631,15 @@ void DialogEditProfile::typeSelected(const QString &newType) {
     ui->bean->layout()->addWidget(innerWidget);
     ui->bean->setTitle(ent->outbound->DisplayType());
     delete old;
+
+    // Update tab order to include innerWidget
+    const auto innerTabOrder = collectTabOrder(this, innerWidget);
+    if (!innerTabOrder.isEmpty() && innerTabOrderIndex >= 0 && innerTabOrderIndex <= outerTabOrder.size()) {
+        auto completeTabOrder = outerTabOrder.mid(0, innerTabOrderIndex);
+        completeTabOrder.append(innerTabOrder);
+        completeTabOrder.append(outerTabOrder.mid(innerTabOrderIndex));
+        rebuildTabOrder(completeTabOrder);
+    }
 
     // 左边 bean inner editor
     innerEditor->get_edit_dialog = [&]() { return static_cast<QWidget*>(this); };


### PR DESCRIPTION
## Summary

This PR improves keyboard Tab navigation in profile editor dialogs.

- Added explicit tab order definitions to the shared profile dialog and all embedded profile editor forms.
- Ensured that Tab navigation follows the visual and logical order of fields for profile types such as WireGuard, Hysteria, Mieru, and other embedded editors.
- Added runtime composition of the tab order when `DialogEditProfile` inserts the editor widget for the selected profile type.

## Implementation details

`DialogEditProfile` contains a shared set of profile fields and dynamically inserts a type-specific editor widget into the `bean` container.

The tab order is composed as follows:

1. After `DialogEditProfile::setupUi()`, the original tab order of the outer dialog is collected and saved.
2. The `fake` widget in `dialog_edit_profile.ui` acts as a tab-order insertion marker. Its position is saved and then removed from the stored outer order.
3. When a type-specific editor is inserted, its own tab order is collected from the Qt focus chain.
4. The embedded editor's order is inserted at the saved marker position.
5. The complete `DialogEditProfile` focus chain is rebuilt sequentially with `QWidget::setTabOrder()`.

This avoids partial focus-chain updates, which could otherwise place `OK` and `Cancel` between fields of an embedded editor.

## Testing

- Built successfully on Windows with MSVC 2022 and Qt 6.10.1:

  ```powershell
  cmake --build build --config RelWithDebInfo
  ```

- Manually verified Tab navigation in the profile editor, including dynamically embedded editors.