### PR TITLE
Fix Xray raw HTTP imports and VMess share links

### DIFF
--- a/include/configs/common/xrayStreamSetting.h
+++ b/include/configs/common/xrayStreamSetting.h
@@ -146,6 +146,7 @@ namespace Configs {
         public:
         QString network = "raw";
         QString security = "none";
+        QJsonObject rawSettings;
         std::shared_ptr<xrayTLS> TLS = std::make_shared<xrayTLS>();
         std::shared_ptr<xrayReality> reality = std::make_shared<xrayReality>();
         std::shared_ptr<xrayXHTTP> xhttp = std::make_shared<xrayXHTTP>();

--- a/src/configs/common/utils.cpp
+++ b/src/configs/common/utils.cpp
@@ -51,8 +51,12 @@ namespace Configs
         auto url = QUrl(link);
         if (!url.isValid()) return false;
         auto query = QUrlQuery(url.query());
+        const auto transport = query.queryItemValue("type");
+        const bool rawHttp = (transport == "tcp" || transport == "raw")
+                             && query.queryItemValue("headerType") == "http";
 
         if (dataManager->settingsRepo->xray_vless_preference == Xray::AllVLESS
+            || rawHttp
             || query.queryItemValue("type") == "xhttp"
             || (query.queryItemValue("security") == "reality" && dataManager->settingsRepo->xray_vless_preference == Xray::XhttpAndReality)
             || (query.queryItemValue("encryption") != "none" && query.queryItemValue("encryption") != "")

--- a/src/configs/common/xrayStreamSetting.cpp
+++ b/src/configs/common/xrayStreamSetting.cpp
@@ -749,6 +749,18 @@ namespace Configs {
 
         if (query.hasQueryItem("type")) network = query.queryItemValue("type").replace("tcp", "raw");
         if (!Configs::XrayNetworks.contains(network)) return false;
+        if (network == "raw" && query.queryItemValue("headerType") == "http") {
+            QJsonObject request;
+            if (const auto path = query.queryItemValue("path", QUrl::FullyDecoded); !path.isEmpty()) {
+                request["path"] = QJsonArray{path};
+            }
+            if (const auto host = query.queryItemValue("host", QUrl::FullyDecoded); !host.isEmpty()) {
+                request["headers"] = QJsonObject{{"Host", QJsonArray::fromStringList(host.split(','))}};
+            }
+            QJsonObject header{{"type", "http"}};
+            if (!request.isEmpty()) header["request"] = request;
+            rawSettings = QJsonObject{{"header", header}};
+        }
         if (query.hasQueryItem("security")) security = query.queryItemValue("security");
         if (security == "tls") TLS->ParseFromLink(link);
         else if (security == "reality") reality->ParseFromLink(link);
@@ -763,8 +775,14 @@ namespace Configs {
     bool xrayStreamSetting::ParseFromJson(const QJsonObject &object) {
         if (object.isEmpty()) return false;
 
-        if (object.contains("network")) network = object.value("network").toString();
+        if (object.contains("method")) network = object.value("method").toString();
+        else if (object.contains("network")) network = object.value("network").toString();
+        if (network == "tcp") network = "raw";
         if (!Configs::XrayNetworks.contains(network)) return false;
+        if (network == "raw") {
+            if (object["rawSettings"].isObject()) rawSettings = object["rawSettings"].toObject();
+            else if (object["tcpSettings"].isObject()) rawSettings = object["tcpSettings"].toObject();
+        }
         if (object.contains("security")) security = object.value("security").toString();
         if (security == "tls" && object["tlsSettings"].isObject()) TLS->ParseFromJson(object["tlsSettings"].toObject());
         else if (security == "reality" && object["realitySettings"].isObject()) reality->ParseFromJson(object["realitySettings"].toObject());
@@ -802,7 +820,15 @@ namespace Configs {
 
     QString xrayStreamSetting::ExportToLink() {
         QUrlQuery query;
-        if (!network.isEmpty()) query.addQueryItem("type", network);
+        if (!network.isEmpty()) query.addQueryItem("type", network == "raw" ? "tcp" : network);
+        if (network == "raw" && rawSettings["header"].toObject()["type"] == "http") {
+            query.addQueryItem("headerType", "http");
+            const auto request = rawSettings["header"].toObject()["request"].toObject();
+            const auto paths = request["path"].toArray();
+            if (!paths.isEmpty()) query.addQueryItem("path", paths.first().toString());
+            const auto hosts = request["headers"].toObject()["Host"].toArray();
+            if (!hosts.isEmpty()) query.addQueryItem("host", QJsonArray2QListString(hosts).join(','));
+        }
         if (!security.isEmpty()) query.addQueryItem("security", security);
         if (security == "tls") mergeUrlQuery(query, TLS->ExportToLink());
         if (security == "reality") mergeUrlQuery(query, reality->ExportToLink());
@@ -817,6 +843,7 @@ namespace Configs {
         QJsonObject object;
         object["network"] = network;
         object["security"] = security;
+        if (network == "raw" && !rawSettings.isEmpty()) object["rawSettings"] = rawSettings;
         if (security == "tls") object["tlsSettings"] = TLS->ExportToJson();
         else if (security == "reality") object["realitySettings"] = reality->ExportToJson();
         if (network == "xhttp") object["xhttpSettings"] = xhttp->ExportToJson();
@@ -830,6 +857,7 @@ namespace Configs {
         QJsonObject object;
         object["network"] = network;
         object["security"] = security;
+        if (network == "raw" && !rawSettings.isEmpty()) object["rawSettings"] = rawSettings;
         if (security == "reality") {
             if (!reality->serverName.isEmpty()) object["sni"] = reality->serverName;
             if (!reality->fingerprint.isEmpty()) object["fingerprint"] = reality->fingerprint;

--- a/src/configs/outbounds/vmess.cpp
+++ b/src/configs/outbounds/vmess.cpp
@@ -1,5 +1,6 @@
 #include "include/configs/outbounds/vmess.h"
 
+#include <QJsonDocument>
 #include <QUrlQuery>
 #include <include/global/Utils.hpp>
 
@@ -24,7 +25,8 @@ namespace Configs {
                 if (QString type = objN["type"].toString(); type == "http") net = "http";
                 transport->type = net;
                 transport->host = objN["host"].toString();
-                transport->path = objN["path"].toString();
+                if (net == "grpc") transport->service_name = objN["path"].toString();
+                else transport->path = objN["path"].toString();
                 
                 QString scy = objN["scy"].toString();
                 if (!scy.isEmpty()) security = scy;
@@ -33,6 +35,13 @@ namespace Configs {
                 if (tlsStr == "tls") {
                     tls->enabled = true;
                     tls->server_name = objN["sni"].toString();
+                }
+                tls->alpn = objN["alpn"].toString().split(',', Qt::SkipEmptyParts);
+                const auto insecure = objN["insecure"].toString();
+                tls->insecure = insecure == "1" || insecure == "true";
+                if (const auto fingerprint = objN["fp"].toString(); !fingerprint.isEmpty()) {
+                    tls->utls->enabled = true;
+                    tls->utls->fingerPrint = fingerprint;
                 }
                 
                 return !(uuid.isEmpty() || server.isEmpty());
@@ -103,27 +112,30 @@ namespace Configs {
 
     QString vmess::ExportToLink()
     {
-        QUrl url;
-        QUrlQuery query;
-        url.setScheme("vmess");
-        url.setUserName(uuid);
-        url.setHost(server);
-        url.setPort(server_port);
-        if (!name.isEmpty()) url.setFragment(name);
-
-        if (security != "auto") query.addQueryItem("encryption", security);
-
-        mergeUrlQuery(query, tls->ExportToLink());
-        mergeUrlQuery(query, transport->ExportToLink());
-        mergeUrlQuery(query, multiplex->ExportToLink());
-        
-        if (alter_id > 0) query.addQueryItem("alterId", QString::number(alter_id));
-        if (global_padding) query.addQueryItem("globalPadding", "true");
-        if (authenticated_length) query.addQueryItem("authenticatedLength", "true");
-        query.addQueryItem("packetEncoding", packet_encoding.isEmpty() ? "none" : packet_encoding);
-        
-        if (!query.isEmpty()) url.setQuery(query);
-        return url.toString(QUrl::FullyEncoded);
+        const auto network = transport->type.isEmpty() || transport->type == "tcp"
+                                 ? QStringLiteral("tcp")
+                                 : transport->type == "http" ? QStringLiteral("h2") : transport->type;
+        const auto path = network == "grpc" ? transport->service_name : transport->path;
+        const QJsonObject object{
+            {"v", "2"},
+            {"ps", name},
+            {"add", server},
+            {"port", QString::number(server_port)},
+            {"id", uuid},
+            {"aid", QString::number(alter_id)},
+            {"scy", security.isEmpty() ? QStringLiteral("auto") : security},
+            {"net", network},
+            {"type", "none"},
+            {"host", transport->host},
+            {"path", path},
+            {"tls", tls->enabled ? QStringLiteral("tls") : QString()},
+            {"sni", tls->server_name},
+            {"alpn", tls->alpn.join(',')},
+            {"fp", tls->utls->fingerPrint},
+            {"insecure", tls->insecure ? QStringLiteral("1") : QStringLiteral("0")},
+        };
+        const auto payload = QJsonDocument(object).toJson(QJsonDocument::Compact).toBase64();
+        return QStringLiteral("vmess://") + QString::fromLatin1(payload);
     }
 
     QJsonObject vmess::ExportToJson()


### PR DESCRIPTION
## Summary

- preserve Xray raw HTTP header settings during VLESS import and export
- route raw HTTP VLESS profiles through Xray
- export VMess Copy Link and QR payloads as Base64 JSON
- keep both Base64 JSON and readable VMess URI imports

## Verification

- built Throne with MSVC 2022 and Qt 6
- imported both supported VMess link forms in the built app
- confirmed UUID, server, port, UTF-8 name, TLS fields, and xudp packet encoding
- validated the affected raw HTTP VLESS profiles with Xray
