### PR TITLE
Add a top bar button for one-click group url test

### DIFF
--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -381,6 +381,35 @@ QToolButton::menu-indicator {
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QToolButton" name="toolButton_urltest">
+        <property name="toolTip">
+         <string>Url test the current group. Click again to stop a running test.</string>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">QToolButton {
+    padding-left: 8px;
+    padding-right: 8px;
+}</string>
+        </property>
+        <property name="text">
+         <string>Url Test Group</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../res/Throne.qrc">
+          <normaloff>:/icon/b-testing-button.png</normaloff>:/icon/b-testing-button.png</iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>24</width>
+          <height>24</height>
+         </size>
+        </property>
+        <property name="toolButtonStyle">
+         <enum>Qt::ToolButtonStyle::ToolButtonTextUnderIcon</enum>
+        </property>
+       </widget>
+      </item>
      </layout>
     </item>
     <item>

--- a/res/translations/zh_CN.ts
+++ b/res/translations/zh_CN.ts
@@ -4104,6 +4104,10 @@ Please start your profile again.</source>
         <translation>URL 测试本组</translation>
     </message>
     <message>
+        <source>Url test the current group. Click again to stop a running test.</source>
+        <translation>URL 测试当前分组。测试进行中再次点击可停止。</translation>
+    </message>
+    <message>
         <source>Hidden menu</source>
         <translation>隐藏菜单</translation>
     </message>

--- a/src/ui/mainWindow/mainwindow_setup.cpp
+++ b/src/ui/mainWindow/mainwindow_setup.cpp
@@ -347,6 +347,11 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     ui->toolButton_testing->setMenu(ui->menuTesting);
     ui->toolButton_tools->setMenu(ui->menuTools);
     ui->toolButton_program->installEventFilter(this);
+    // Mirrors the menus' Stop Testing swap: a second click during a sweep stops it.
+    connect(ui->toolButton_urltest, &QToolButton::clicked, this, [=, this] {
+        if (testRunner->isRunning()) testRunner->stop();
+        else ui->actionUrl_Test_Group->trigger();
+    });
 
     designMinimumSize = minimumSize();
     applyTopBarMetrics();


### PR DESCRIPTION
## What

Adds a tool button at the right end of the top bar that url tests the current group with one click.

## Why

Testing the current group currently takes two clicks: open the `Groups` menu, then `Url Test Group`. It is a frequent action, so a one-click button in the otherwise empty top-right area saves a step.

## Behavior

- Clicking triggers the existing `actionUrl_Test_Group`, the same code path as the menu item / `Ctrl+Shift+G`.
- Clicking again while a sweep is running stops it, mirroring the `Stop Testing` entry the menus swap in (and avoiding the "last test did not exit completely" warning on a double click).
- Styled like the other top bar buttons (24px icon, text under icon, same padding). The label reuses the existing `Url Test Group` string, so no new translation is needed for it; the new tooltip string ships with a zh_CN translation and falls back to English elsewhere until the next lupdate run.

## Screenshot

![top bar with the new Url Test Group button at the right](https://gist.githubusercontent.com/nianshou555qiansui/ac400f9a7f0104e24cbdb2571bca8315/raw/throne-urltest-button.png)
