### PR TITLE
  feat(hysteria): add support for Gecko obfuscation (min_packet_size and max_packet_size)

### DIFF
--- a/include/configs/outbounds/hysteria.h
+++ b/include/configs/outbounds/hysteria.h
@@ -23,6 +23,9 @@ namespace Configs
 
         // Hysteria2
         QString password;
+        int min_packet_size = 0;
+        int max_packet_size = 0;
+        QString obfs_type;
 
         std::shared_ptr<TLS> tls = std::make_shared<TLS>();
 

--- a/include/configs/outbounds/hysteria.h
+++ b/include/configs/outbounds/hysteria.h
@@ -25,7 +25,7 @@ namespace Configs
         QString password;
         int min_packet_size = 0;
         int max_packet_size = 0;
-        QString obfs_type;
+        QString obfs_type = "salamander";
 
         std::shared_ptr<TLS> tls = std::make_shared<TLS>();
 

--- a/include/ui/profile/edit_hysteria.h
+++ b/include/ui/profile/edit_hysteria.h
@@ -21,8 +21,9 @@ public:
     bool onEnd() override;
 
     QComboBox *_protocol_version;
+    QComboBox *_obfuscation_type;
 
-    void editHysteriaLayout(const QString& version);
+    void editHysteriaLayout(const QString& version, const QString& obfs_type);
 private:
     Ui::EditHysteria *ui;
     std::shared_ptr<Configs::Profile> ent;

--- a/include/ui/profile/edit_hysteria.ui
+++ b/include/ui/profile/edit_hysteria.ui
@@ -6,41 +6,16 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>363</height>
+    <width>443</width>
+    <height>535</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string notr="true">Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="protocol_version_l">
-     <property name="text">
-      <string>Protocol Version</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="protocol_version">
-     <item>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string notr="true">2</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Down Mbps</string>
-     </property>
-    </widget>
+   <item row="11" column="1">
+    <widget class="QLineEdit" name="max_packet_size"/>
    </item>
    <item row="7" column="1">
     <widget class="QLineEdit" name="auth"/>
@@ -64,12 +39,28 @@
      </item>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="recv_window_conn_l">
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="server_ports"/>
+   </item>
+   <item row="14" column="1">
+    <widget class="QCheckBox" name="disable_mtu_discovery">
      <property name="text">
-      <string>Recv window conn</string>
+      <string>Disable Mtu Discovery</string>
      </property>
     </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="up_mbps"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Server Ports</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="down_mbps"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_2">
@@ -78,13 +69,58 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="obfs"/>
+   <item row="8" column="1">
+    <widget class="QComboBox" name="obfuscation_type">
+     <item>
+      <property name="text">
+       <string>salamander</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>gecko</string>
+      </property>
+     </item>
+    </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
+   <item row="10" column="1">
+    <widget class="QLineEdit" name="min_packet_size"/>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="min_packet_size_l">
      <property name="text">
-      <string>Server Ports</string>
+      <string>Minimum Packet Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Down Mbps</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="recv_window_conn_l">
+     <property name="text">
+      <string>Recv window conn</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="auth_l">
+     <property name="text">
+      <string>Authentication Payload</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="1">
+    <widget class="QLineEdit" name="password"/>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="recv_window_l">
+     <property name="text">
+      <string>Recv window</string>
      </property>
     </widget>
    </item>
@@ -95,8 +131,22 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
-    <widget class="QLineEdit" name="down_mbps"/>
+   <item row="12" column="1">
+    <widget class="QLineEdit" name="recv_window_conn"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="protocol_version">
+     <item>
+      <property name="text">
+       <string notr="true">1</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string notr="true">2</string>
+      </property>
+     </item>
+    </widget>
    </item>
    <item row="3" column="0">
     <widget class="QLabel" name="label_3">
@@ -105,58 +155,49 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="server_ports"/>
-   </item>
-   <item row="7" column="0">
-    <widget class="QLabel" name="auth_l">
-     <property name="text">
-      <string>Authentication Payload</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="hop_interval"/>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="up_mbps"/>
-   </item>
-   <item row="8" column="1">
-    <widget class="QLineEdit" name="recv_window_conn"/>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Obfuscation Password</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="recv_window_l">
-     <property name="text">
-      <string>Recv window</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QLineEdit" name="recv_window"/>
-   </item>
-   <item row="10" column="1">
-    <widget class="QCheckBox" name="disable_mtu_discovery">
-     <property name="text">
-      <string>Disable Mtu Discovery</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
+   <item row="15" column="0">
     <widget class="QLabel" name="password_l">
      <property name="text">
       <string>Password</string>
      </property>
     </widget>
    </item>
-   <item row="11" column="1">
-    <widget class="QLineEdit" name="password"/>
+   <item row="0" column="0">
+    <widget class="QLabel" name="protocol_version_l">
+     <property name="text">
+      <string>Protocol Version</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="hop_interval"/>
+   </item>
+   <item row="13" column="1">
+    <widget class="QLineEdit" name="recv_window"/>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="max_packet_size_l">
+     <property name="text">
+      <string>Maximum Packet Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Obfuscation Password</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QLineEdit" name="obfs"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="obfuscation_type_l">
+     <property name="text">
+      <string>Obfuscation</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/configs/outbounds/hysteria.cpp
+++ b/src/configs/outbounds/hysteria.cpp
@@ -61,11 +61,14 @@ namespace Configs {
             if (query.hasQueryItem("obfs-password")) {
                 obfs = query.queryItemValue("obfs-password", QUrl::FullyDecoded);
             }
-            if (query.hasQueryItem("min_packet_size") || query.hasQueryItem("max_packet_size")) {
+            if (query.hasQueryItem("obfs")) {
+                obfs_type = query.queryItemValue("obfs");
+            }
+            else if (query.hasQueryItem("min_packet_size") || query.hasQueryItem("max_packet_size")) {
                 obfs_type = "gecko";
             }
             else {
-                obfs_type = "obfs";
+                obfs_type = "salamander";
             }
             if (query.hasQueryItem("min_packet_size")) min_packet_size = query.queryItemValue("min_packet_size").toInt();
             if (query.hasQueryItem("max_packet_size")) max_packet_size = query.queryItemValue("max_packet_size").toInt();
@@ -121,6 +124,7 @@ namespace Configs {
                 auto obfsObj = object["obfs"].toObject();
                 if (obfsObj.contains("password")) obfs = obfsObj["password"].toString();
                 if (obfsObj.contains("type")) obfs_type = obfsObj["type"].toString();
+                else obfs_type = "salamander";
                 if (obfsObj.contains("min_packet_size")) min_packet_size = obfsObj["min_packet_size"].toInt();
                 if (obfsObj.contains("max_packet_size")) max_packet_size = obfsObj["max_packet_size"].toInt();
             }
@@ -229,6 +233,7 @@ namespace Configs {
                 url.setUserName(password);
             }
             if (!obfs.isEmpty()) {
+                query.addQueryItem("obfs", QUrl::toPercentEncoding(obfs_type));
                 query.addQueryItem("obfs-password", QUrl::toPercentEncoding(obfs));
                 if (min_packet_size > 0) query.addQueryItem("min_packet_size", QString::number(min_packet_size));
                 if (max_packet_size > 0) query.addQueryItem("max_packet_size", QString::number(max_packet_size));
@@ -333,12 +338,18 @@ namespace Configs {
                         {"password", obfs},
                     };
                 }
-                if (obfs_type == "gecko") {
+                else if (obfs_type == "gecko") {
                     object["obfs"] = QJsonObject{
                         {"type", obfs_type},
                         {"password", obfs},
                         {"min_packet_size", min_packet_size},
                         {"max_packet_size", max_packet_size},
+                    };
+                }
+                else {
+                    object["obfs"] = QJsonObject{
+                        {"type", "salamander"},
+                        {"password", obfs},
                     };
                 }
             }

--- a/src/configs/outbounds/hysteria.cpp
+++ b/src/configs/outbounds/hysteria.cpp
@@ -61,6 +61,14 @@ namespace Configs {
             if (query.hasQueryItem("obfs-password")) {
                 obfs = query.queryItemValue("obfs-password", QUrl::FullyDecoded);
             }
+            if (query.hasQueryItem("min_packet_size") || query.hasQueryItem("max_packet_size")) {
+                obfs_type = "gecko";
+            }
+            else {
+                obfs_type = "obfs";
+            }
+            if (query.hasQueryItem("min_packet_size")) min_packet_size = query.queryItemValue("min_packet_size").toInt();
+            if (query.hasQueryItem("max_packet_size")) max_packet_size = query.queryItemValue("max_packet_size").toInt();
         }
         
         if (query.hasQueryItem("upmbps")) up_mbps = query.queryItemValue("upmbps").toInt();
@@ -112,6 +120,9 @@ namespace Configs {
             if (object.contains("obfs")) {
                 auto obfsObj = object["obfs"].toObject();
                 if (obfsObj.contains("password")) obfs = obfsObj["password"].toString();
+                if (obfsObj.contains("type")) obfs_type = obfsObj["type"].toString();
+                if (obfsObj.contains("min_packet_size")) min_packet_size = obfsObj["min_packet_size"].toInt();
+                if (obfsObj.contains("max_packet_size")) max_packet_size = obfsObj["max_packet_size"].toInt();
             }
             if (object.contains("obfsPassword")) obfs = object["obfsPassword"].toString();
             if (object.contains("password")) password = object["password"].toString();
@@ -219,6 +230,8 @@ namespace Configs {
             }
             if (!obfs.isEmpty()) {
                 query.addQueryItem("obfs-password", QUrl::toPercentEncoding(obfs));
+                if (min_packet_size > 0) query.addQueryItem("min_packet_size", QString::number(min_packet_size));
+                if (max_packet_size > 0) query.addQueryItem("max_packet_size", QString::number(max_packet_size));
             }
         }
         
@@ -273,8 +286,10 @@ namespace Configs {
         } else {
             if (!obfs.isEmpty()) {
                 object["obfs"] = QJsonObject{
-                    {"type", "salamander"},
+                    {"type", obfs_type},
                     {"password", obfs},
+                    {"min_packet_size", min_packet_size},
+                    {"max_packet_size", max_packet_size},
                 };
             }
             if (!password.isEmpty()) object["password"] = password;
@@ -312,10 +327,20 @@ namespace Configs {
             if (disable_mtu_discovery) object["disable_mtu_discovery"] = disable_mtu_discovery;
         } else {
             if (!obfs.isEmpty()) {
-                object["obfs"] = QJsonObject{
-                    {"type", "salamander"},
-                    {"password", obfs},
-                };
+                if (obfs_type == "salamander") {
+                    object["obfs"] = QJsonObject{
+                        {"type", obfs_type},
+                        {"password", obfs},
+                    };
+                }
+                if (obfs_type == "gecko") {
+                    object["obfs"] = QJsonObject{
+                        {"type", obfs_type},
+                        {"password", obfs},
+                        {"min_packet_size", min_packet_size},
+                        {"max_packet_size", max_packet_size},
+                    };
+                }
             }
             if (!password.isEmpty()) object["password"] = password;
         }

--- a/src/ui/profile/dialog_edit_profile.cpp
+++ b/src/ui/profile/dialog_edit_profile.cpp
@@ -419,10 +419,22 @@ void DialogEditProfile::typeSelected(const QString &newType) {
         auto _innerWidget = new EditHysteria(this);
         innerWidget = _innerWidget;
         innerEditor = _innerWidget;
-        connect(_innerWidget->_protocol_version, &QComboBox::currentTextChanged, _innerWidget, [=,this](const QString &txt)
-        {
-            _innerWidget->editHysteriaLayout(txt);
+
+        auto updateLayout = [_innerWidget, this]() {
+            _innerWidget->editHysteriaLayout(
+                _innerWidget->_protocol_version->currentText(),
+                _innerWidget->_obfuscation_type->currentText()
+            );
             queueRefreshDialogLayout();
+        };
+
+        connect(_innerWidget->_protocol_version, &QComboBox::currentTextChanged, _innerWidget, [=](const QString &)
+        {
+            updateLayout();
+        });
+        connect(_innerWidget->_obfuscation_type, &QComboBox::currentTextChanged, _innerWidget, [=](const QString &)
+        {
+            updateLayout();
         });
     } else if (type == "tuic") {
         auto _innerWidget = new EditTuic(this);

--- a/src/ui/profile/edit_hysteria.cpp
+++ b/src/ui/profile/edit_hysteria.cpp
@@ -1,4 +1,5 @@
 #include "include/ui/profile/edit_hysteria.h"
+#include "include/global/Utils.hpp"
 
 EditHysteria::EditHysteria(QWidget *parent)
     : QWidget(parent),
@@ -6,6 +7,7 @@ EditHysteria::EditHysteria(QWidget *parent)
     ui->setupUi(this);
 
     _protocol_version = ui->protocol_version;
+    _obfuscation_type = ui->obfuscation_type;
 }
 
 EditHysteria::~EditHysteria() {
@@ -28,7 +30,11 @@ void EditHysteria::onStart(std::shared_ptr<Configs::Profile> _ent) {
     ui->recv_window_conn->setText(Int2String(outbound->recv_window_conn));
     ui->disable_mtu_discovery->setChecked(outbound->disable_mtu_discovery);
     ui->password->setText(outbound->password);
-    editHysteriaLayout(outbound->protocol_version);
+    ui->min_packet_size->setText(Int2String(outbound->min_packet_size));
+    ui->max_packet_size->setText(Int2String(outbound->max_packet_size));
+    ui->obfuscation_type->setCurrentText(outbound->obfs_type);
+    ui->password->setText(outbound->password);
+    editHysteriaLayout(outbound->protocol_version, outbound->obfs_type);
 }
 
 bool EditHysteria::onEnd() {
@@ -45,10 +51,13 @@ bool EditHysteria::onEnd() {
     outbound->recv_window_conn = ui->recv_window_conn->text().toInt();
     outbound->disable_mtu_discovery = ui->disable_mtu_discovery->isChecked();
     outbound->password = ui->password->text();
+    outbound->min_packet_size = ui->min_packet_size->text().toInt();
+    outbound->max_packet_size = ui->max_packet_size->text().toInt();
+    outbound->obfs_type = ui->obfuscation_type->currentText();
     return true;
 }
 
-void EditHysteria::editHysteriaLayout(const QString& version) {
+void EditHysteria::editHysteriaLayout(const QString& version, const QString& obfs_type) {
     if (version == "1")
     {
         ui->auth_type->setVisible(true);
@@ -62,6 +71,12 @@ void EditHysteria::editHysteriaLayout(const QString& version) {
         ui->disable_mtu_discovery->setVisible(true);
         ui->password->setVisible(false);
         ui->password_l->setVisible(false);
+        ui->min_packet_size->setVisible(false);
+        ui->min_packet_size_l->setVisible(false);
+        ui->max_packet_size->setVisible(false);
+        ui->max_packet_size_l->setVisible(false);
+        ui->obfuscation_type->setVisible(false);
+        ui->obfuscation_type_l->setVisible(false);
     } else
     {
         ui->auth_type->setVisible(false);
@@ -75,5 +90,19 @@ void EditHysteria::editHysteriaLayout(const QString& version) {
         ui->disable_mtu_discovery->setVisible(false);
         ui->password->setVisible(true);
         ui->password_l->setVisible(true);
+        ui->obfuscation_type->setVisible(true);
+        ui->obfuscation_type_l->setVisible(true);
+        if (obfs_type == "gecko") {
+            ui->min_packet_size->setVisible(true);
+            ui->min_packet_size_l->setVisible(true);
+            ui->max_packet_size->setVisible(true);
+            ui->max_packet_size_l->setVisible(true);
+        }
+        if (obfs_type == "salamander") {
+            ui->min_packet_size->setVisible(false);
+            ui->min_packet_size_l->setVisible(false);
+            ui->max_packet_size->setVisible(false);
+            ui->max_packet_size_l->setVisible(false);
+        }
     }
 }


### PR DESCRIPTION
 # Summary of Changes

Adds support for Gecko obfuscation in Hysteria profiles. This includes UI controls for selecting obfuscation types and configuring packet size limits (min_packet_size, max_packet_size), dynamic form layout handling, and full support for link parsing, JSON serialization, and export generation.

Salamander obfuscation
<img width="936" height="653" alt="image" src="https://github.com/user-attachments/assets/830567b0-13a1-4e81-b91a-3fc4f19eb960" />

Gecko obfuscation
<img width="936" height="717" alt="image" src="https://github.com/user-attachments/assets/40463bbf-dd73-43d9-9558-5872b83e70b9" />
  
  # Key Changes

## 1. Config Model & Serialization (hysteria.h, hysteria.cpp)

- Added min_packet_size, max_packet_size, and obfs_type fields to the Configs::hysteria outbound model.
- Link Parsing & Export:
    - Parses min_packet_size and max_packet_size from link query parameters.
    - Automatically identifies gecko obfuscation if packet size parameters are present.
    - Appends packet size parameters when exporting share links.
- JSON / Clash Parsing & Build:
    - Added support for parsing type, min_packet_size, and max_packet_size under the obfs JSON object.
    - Generates appropriate config output for both salamander and gecko obfuscation types in JSON/outbound build results.

## 2. UI & Form Layout (edit_hysteria.ui, edit_hysteria.cpp, dialog_edit_profile.cpp)

- Added obfuscation_type dropdown (salamander, gecko) and input fields for min_packet_size and max_packet_size.
- Dynamic Layout Toggling:
    - Updated editHysteriaLayout to conditionally toggle visibility of min_packet_size and max_packet_size based on the selected obfs_type (visible for gecko, hidden for salamander or Hysteria v1).
    - Connected currentTextChanged signals for both _protocol_version and _obfuscation_type in DialogEditProfile to refresh the form dynamically when changed by the user.
- Updated onStart and onEnd methods to properly load from and persist values to the profile entity.

# How to Test

1. Open Edit Profile for a Hysteria outbound.
2. Switch between Hysteria v1 and Hysteria v2:
    - Verify Hysteria v1 hides all v2-specific fields (obfuscation type, packet sizes).
3. In Hysteria v2, change the Obfuscation Type:
    - Selecting gecko should reveal the Min Packet Size and Max Packet Size inputs.
    - Selecting salamander should hide them.
4. Save the profile and verify that JSON configs / share links export the min_packet_size and max_packet_size correctly.
5. Import a Hysteria link containing gecko parameters and verify fields are populated.