### PR TITLE
Update: desktop entry in python installer

### DIFF
--- a/script/install_linux.py
+++ b/script/install_linux.py
@@ -266,13 +266,17 @@ def main(scr, y):
             y = message(scr, y, "Creating .desktop file")
             with open(tmpdir / "Throne.desktop", "w") as file:
                 file.write(f"""[Desktop Entry]
+Version={version}
 Name=Throne
+GenericName=Proxy Manager
 Comment=Qt based cross-platform GUI proxy configuration manager (backend: sing-box)
 Exec={APPDIR}/Throne -appdata
 Icon={APPDIR}/Throne.png
+StartupWMClass=Throne
 Terminal=false
 Type=Application
 Categories=Network;Application;
+Keywords=proxy;vpn;network;privacy;
 """)
 
             with open(tmpdir / "Version", "w") as file:


### PR DESCRIPTION
Update `Throne.desktop` with

- Application `Version`

  ```desktop
  Version={version}
  ```
- `GenericName`
- `Keywords` for better App discovery/search in `gdm`
  - Discoverability: New users might not know the app is called "Throne"; they might search for "proxy" or "vpn"
  - GNOME integration: Works with GNOME's global search functionality
- `StartupWMClass`
  - Group windows together
  - Handle task switching - Alt+Tab shows Throne correctly
  - Apply window rules - GNOME can remember size/position preferences for Throne