### PR TITLE
3rdparty: bump vendored fkYAML to v0.4.4 (fixes #1746 subscription-import crashes)

### DIFF
--- a/3rdparty/fkYAML/node.hpp
+++ b/3rdparty/fkYAML/node.hpp
@@ -1,12 +1,13 @@
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
-#pragma once
+#ifndef FK_YAML_NODE_HPP
+#define FK_YAML_NODE_HPP
 
 #include <algorithm>
 #include <cstdint>
@@ -21,10 +22,10 @@
 // #include <fkYAML/detail/macros/define_macros.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_MACROS_DEFINE_MACROS_HPP
@@ -33,15 +34,15 @@
 // #include <fkYAML/detail/macros/version_macros.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 // Check version definitions if already defined.
 #if defined(FK_YAML_MAJOR_VERSION) && defined(FK_YAML_MINOR_VERSION) && defined(FK_YAML_PATCH_VERSION)
-#if FK_YAML_MAJOR_VERSION != 0 || FK_YAML_MINOR_VERSION != 4 || FK_YAML_PATCH_VERSION != 2
+#if FK_YAML_MAJOR_VERSION != 0 || FK_YAML_MINOR_VERSION != 4 || FK_YAML_PATCH_VERSION != 4
 #warning Already included a different version of the fkYAML library!
 #else
 // define macros to skip defining macros down below.
@@ -53,7 +54,7 @@
 
 #define FK_YAML_MAJOR_VERSION 0
 #define FK_YAML_MINOR_VERSION 4
-#define FK_YAML_PATCH_VERSION 2
+#define FK_YAML_PATCH_VERSION 4
 
 #define FK_YAML_NAMESPACE_VERSION_CONCAT_IMPL(major, minor, patch) v##major##_##minor##_##patch
 
@@ -83,10 +84,10 @@
 // #include <fkYAML/detail/macros/cpp_config_macros.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_MACROS_CPP_CONFIG_MACROS_HPP
@@ -242,10 +243,10 @@
 // #include <fkYAML/detail/assert.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ASSERT_HPP
@@ -266,10 +267,10 @@
 // #include <fkYAML/detail/document_metainfo.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_DOCUMENT_METAINFO_HPP
@@ -283,10 +284,10 @@
 // #include <fkYAML/detail/meta/node_traits.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_META_NODE_TRAITS_HPP
@@ -297,10 +298,10 @@
 // #include <fkYAML/detail/meta/detect.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_META_DETECT_HPP
@@ -314,10 +315,10 @@
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_META_STL_SUPPLEMENT_HPP
@@ -762,10 +763,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/meta/type_traits.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_META_TYPE_TRAITS_HPP
@@ -859,10 +860,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/fkyaml_fwd.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_FKYAML_FWD_HPP
@@ -1054,10 +1055,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/yaml_version_type.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_YAML_VERSION_TYPE_HPP
@@ -1119,10 +1120,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/exception_safe_allocation.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_EXCEPTION_SAFE_ALLOCATION_HPP
@@ -1231,10 +1232,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/deserializer.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_DESERIALIZER_HPP
@@ -1242,6 +1243,7 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #include <algorithm>
 #include <deque>
+#include <memory>
 #include <vector>
 
 // #include <fkYAML/detail/macros/define_macros.hpp>
@@ -1251,10 +1253,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/lexical_analyzer.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_LEXICAL_ANALYZER_HPP
@@ -1271,10 +1273,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/encodings/uri_encoding.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ENCODINGS_URI_ENCODING_HPP
@@ -1309,6 +1311,11 @@ public:
                     return false;
                 }
 
+                // validate_octets() advances `current` past the last octet it consumed. Without
+                // moving it back, the loop's own ++current skips the character which follows the
+                // escape sequence, and, when the escape ends the sequence, moves `current` one
+                // past `end` so that the loop condition never holds and reads out of bounds.
+                --current;
                 continue;
             }
 
@@ -1399,10 +1406,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/encodings/utf_encodings.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ENCODINGS_UTF_ENCODINGS_HPP
@@ -1416,10 +1423,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/exception.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_EXCEPTION_HPP
@@ -1435,10 +1442,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/string_formatter.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_STRING_FORMATTER_HPP
@@ -1485,10 +1492,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/types/node_t.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_TYPES_NODE_T_HPP
@@ -1501,10 +1508,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/node_type.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_NODE_TYPE_HPP
@@ -2083,10 +2090,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/block_scalar_header.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_BLOCK_SCALAR_HEADER_HPP
@@ -2121,10 +2128,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/position_tracker.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_POSITION_TRACKER_HPP
@@ -2137,10 +2144,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/str_view.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_STR_VIEW_HPP
@@ -3202,10 +3209,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/types/lexical_token_t.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_TYPES_LEXICAL_TOKEN_T_HPP
@@ -3469,7 +3476,11 @@ public:
         case '>': {
             const str_view sv {m_token_begin_itr, m_end_itr};
             const std::size_t header_end_pos = sv.find('\n');
-            FK_YAML_ASSERT(header_end_pos != str_view::npos);
+            if FK_YAML_UNLIKELY (header_end_pos == str_view::npos) {
+                emit_error(
+                    "Invalid block scalar header found. The header must be followed by a line break and its content.");
+            }
+
             const uint32_t base_indent = get_current_indent_level(&sv[header_end_pos]);
 
             const lexical_token_t type = *m_token_begin_itr == '|' ? lexical_token_t::BLOCK_LITERAL_SCALAR
@@ -3777,6 +3788,11 @@ private:
         // extract a tag prefix.
         //
 
+        // skip_white_spaces() above may have consumed the rest of the input buffer.
+        if FK_YAML_UNLIKELY (m_cur_itr == m_end_itr) {
+            emit_error("invalid TAG directive is found.");
+        }
+
         m_token_begin_itr = m_cur_itr;
         const char* p_tag_prefix_begin = m_cur_itr;
         switch (*m_cur_itr) {
@@ -3907,7 +3923,9 @@ private:
         case '<':
             // Verbatim tags (!<TAG>)
             is_verbatim = true;
-            ++m_cur_itr;
+            if FK_YAML_UNLIKELY (++m_cur_itr == m_end_itr) {
+                emit_error("verbatim tag (!<TAG>) must be ended with \'>\'.");
+            }
             break;
         default:
             // Either local tags (!suffix) or named handles (!tag!suffix)
@@ -4039,12 +4057,18 @@ private:
                 // * even number of backslashes -> double quotation mark IS NOT escaped (e.g., "\\"")
                 uint32_t backslash_counts = 0;
                 const char* p = m_token_begin_itr + (pos - 1);
-                do {
-                    if (*p-- != '\\') {
+                for (;;) {
+                    if (*p != '\\') {
                         break;
                     }
                     ++backslash_counts;
-                } while (p != m_token_begin_itr);
+                    if (p == m_token_begin_itr) {
+                        // the first character of the token has just been counted. Stopping here
+                        // also keeps `p` from being decremented past the beginning of the token.
+                        break;
+                    }
+                    --p;
+                }
                 is_closed = ((backslash_counts & 1u) == 0); // true: even, false: odd
             }
 
@@ -4112,36 +4136,26 @@ private:
                 // followed by the comment prefix " #".
                 // Also, flow indicators are not allowed to be followed after a space in a flow context.
                 // See https://yaml.org/spec/1.2.2/#733-plain-style for more details.
-                {
-                    const std::size_t next_non_space = sv.find_first_not_of(" \t", pos + 1);
-                    if (next_non_space == str_view::npos) {
-                        ends_loop = true;
-                        break;
-                    }
-
-                    const char next_char = sv[next_non_space];
-                    switch (next_char) {
-                    case '\n':
-                    case '#':
-                        ends_loop = true;
-                        break;
-                    case ':':
-                        // " :" is permitted in a plain style string token, but not when followed by a space.
-                        if (next_non_space + 1 < sv.size()) {
-                            const char after_colon = sv[next_non_space + 1];
-                            ends_loop = (after_colon == ' ' || after_colon == '\t' || after_colon == '\n');
-                        }
-                        break;
-                    case '{':
-                    case '}':
-                    case '[':
-                    case ']':
-                    case ',':
-                        ends_loop = (m_state & flow_context_bit);
-                        break;
-                    default:
-                        break;
-                    }
+                switch (sv[pos + 1]) {
+                case ' ':
+                case '\t':
+                case '\n':
+                case '#':
+                    ends_loop = true;
+                    break;
+                case ':':
+                    // " :" is permitted in a plain style string token, but not when followed by a space.
+                    ends_loop = (pos < sv.size() - 2) && (sv[pos + 2] == ' ');
+                    break;
+                case '{':
+                case '}':
+                case '[':
+                case ']':
+                case ',':
+                    ends_loop = (m_state & flow_context_bit);
+                    break;
+                default:
+                    break;
                 }
                 break;
             case ':':
@@ -4240,7 +4254,9 @@ private:
         }
 
         if (indicated_indent == 0) {
-            FK_YAML_ASSERT(base_indent < cur_indent);
+            if FK_YAML_UNLIKELY (base_indent >= cur_indent) {
+                emit_error("The first non-empty line in the block scalar is less indented.");
+            }
             indicated_indent = cur_indent - base_indent;
         }
         else if FK_YAML_UNLIKELY (cur_indent < base_indent + indicated_indent) {
@@ -4512,10 +4528,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/scalar_parser.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_SCALAR_PARSER_HPP
@@ -4528,10 +4544,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/conversions/scalar_conv.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 // **NOTE FOR LIBRARY DEVELOPERS**:
@@ -5365,13 +5381,491 @@ FK_YAML_DETAIL_NAMESPACE_END
 
 #endif /* FK_YAML_CONVERSIONS_SCALAR_CONV_HPP */
 
+// #include <fkYAML/detail/conversions/to_node.hpp>
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_CONVERSIONS_TO_NODE_HPP
+#define FK_YAML_DETAIL_CONVERSIONS_TO_NODE_HPP
+
+#include <utility>
+
+// #include <fkYAML/detail/macros/define_macros.hpp>
+
+// #include <fkYAML/detail/exception_safe_allocation.hpp>
+
+// #include <fkYAML/detail/meta/node_traits.hpp>
+
+// #include <fkYAML/detail/meta/type_traits.hpp>
+
+// #include <fkYAML/detail/meta/stl_supplement.hpp>
+
+// #include <fkYAML/detail/node_attrs.hpp>
+//  _______   __ __   __  _____   __  __  __
+// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
+// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
+//
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-License-Identifier: MIT
+
+#ifndef FK_YAML_DETAIL_NODE_ATTRS_HPP
+#define FK_YAML_DETAIL_NODE_ATTRS_HPP
+
+#include <cstdint>
+#include <limits>
+
+// #include <fkYAML/detail/macros/define_macros.hpp>
+
+// #include <fkYAML/node_type.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+/// @brief The type for node attribute bits.
+using node_attr_t = uint32_t;
+
+/// @brief The namespace to define bit masks for node attribute bits.
+namespace node_attr_mask {
+
+/// The bit mask for node value type bits.
+constexpr node_attr_t value = 0x0000FFFFu;
+/// The bit mask for node style type bits. (bits are not yet defined.)
+constexpr node_attr_t style = 0x00FF0000u;
+/// The bit mask for node property related bits.
+constexpr node_attr_t props = 0xFF000000u;
+/// The bit mask for anchor/alias node type bits.
+constexpr node_attr_t anchoring = 0x03000000u;
+/// The bit mask for anchor offset value bits.
+constexpr node_attr_t anchor_offset = 0xFC000000u;
+/// The bit mask for all the bits for node attributes.
+constexpr node_attr_t all = std::numeric_limits<node_attr_t>::max();
+
+} // namespace node_attr_mask
+
+/// @brief The namespace to define bits for node attributes.
+namespace node_attr_bits {
+
+/// The sequence node bit.
+constexpr node_attr_t seq_bit = 1u << 0;
+/// The mapping node bit.
+constexpr node_attr_t map_bit = 1u << 1;
+/// The null scalar node bit.
+constexpr node_attr_t null_bit = 1u << 2;
+/// The boolean scalar node bit.
+constexpr node_attr_t bool_bit = 1u << 3;
+/// The integer scalar node bit.
+constexpr node_attr_t int_bit = 1u << 4;
+/// The floating point scalar node bit.
+constexpr node_attr_t float_bit = 1u << 5;
+/// The string scalar node bit.
+constexpr node_attr_t string_bit = 1u << 6;
+
+/// A utility bit set to filter scalar node bits.
+constexpr node_attr_t scalar_bits = null_bit | bool_bit | int_bit | float_bit | string_bit;
+
+/// The unsigned integer flag bit.
+/// Set on INTEGER nodes whose stored int64_t value represents a uint64_t that exceeds INT64_MAX.
+/// This allows values such as xxHash/UUID results to round-trip correctly through get_value<uint64_t>().
+constexpr node_attr_t uint_bit = 1u << 16; // lives in the style bits area (0x00FF0000)
+
+/// The anchor node bit.
+constexpr node_attr_t anchor_bit = 0x01000000u;
+/// The alias node bit.
+constexpr node_attr_t alias_bit = 0x02000000u;
+
+/// A utility bit set for initialization.
+constexpr node_attr_t default_bits = null_bit;
+
+/// @brief Converts a node_type value to a node_attr_t value.
+/// @param t A type of node value.
+/// @return The associated node value bit.
+inline node_attr_t from_node_type(node_type t) noexcept {
+    switch (t) {
+    case node_type::SEQUENCE:
+        return seq_bit;
+    case node_type::MAPPING:
+        return map_bit;
+    case node_type::NULL_OBJECT:
+        return null_bit;
+    case node_type::BOOLEAN:
+        return bool_bit;
+    case node_type::INTEGER:
+        return int_bit;
+    case node_type::FLOAT:
+        return float_bit;
+    case node_type::STRING:
+        return string_bit;
+    default:                        // LCOV_EXCL_LINE
+        return node_attr_mask::all; // LCOV_EXCL_LINE
+    }
+}
+
+/// @brief Converts a node_attr_t value to a node_type value.
+/// @param bits node attribute bits
+/// @return An associated node value type with the given node value bit.
+inline node_type to_node_type(node_attr_t bits) noexcept {
+    switch (bits & node_attr_mask::value) {
+    case seq_bit:
+        return node_type::SEQUENCE;
+    case map_bit:
+        return node_type::MAPPING;
+    case null_bit:
+        return node_type::NULL_OBJECT;
+    case bool_bit:
+        return node_type::BOOLEAN;
+    case int_bit:
+        return node_type::INTEGER;
+    case float_bit:
+        return node_type::FLOAT;
+    case string_bit:
+        return node_type::STRING;
+    default:                   // LCOV_EXCL_LINE
+        detail::unreachable(); // LCOV_EXCL_LINE
+    }
+}
+
+/// @brief Get an anchor offset used to reference an anchor node from the given attribute bits.
+/// @param attrs node attribute bits
+/// @return An anchor offset value.
+inline uint32_t get_anchor_offset(node_attr_t attrs) noexcept {
+    return (attrs & node_attr_mask::anchor_offset) >> 26;
+}
+
+/// @brief Set an anchor offset value to the appropriate bits.
+/// @param offset An anchor offset value.
+/// @param attrs node attribute bit set into which the offset value is written.
+inline void set_anchor_offset(uint32_t offset, node_attr_t& attrs) noexcept {
+    attrs &= ~node_attr_mask::anchor_offset;
+    attrs |= (offset & 0x3Fu) << 26;
+}
+
+} // namespace node_attr_bits
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_NODE_ATTRS_HPP */
+
+// #include <fkYAML/node_type.hpp>
+
+
+FK_YAML_DETAIL_NAMESPACE_BEGIN
+
+///////////////////////////////////
+//   external_node_constructor   //
+///////////////////////////////////
+
+/// @brief The external constructor template for basic_node objects.
+/// @note All the non-specialized instantiations results in compilation error since such instantiations are not
+/// supported.
+/// @warning All the specialization must call n.m_value.destroy() first in the construct function to avoid
+/// memory leak.
+/// @tparam node_type The resulting YAML node value type.
+template <typename BasicNodeType>
+struct external_node_constructor {
+    template <typename... Args>
+    static void sequence(BasicNodeType& n, Args&&... args) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::seq_bit;
+        n.m_value.p_seq = create_object<typename BasicNodeType::sequence_type>(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    static void mapping(BasicNodeType& n, Args&&... args) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::map_bit;
+        n.m_value.p_map = create_object<typename BasicNodeType::mapping_type>(std::forward<Args>(args)...);
+    }
+
+    static void null_scalar(BasicNodeType& n, std::nullptr_t) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::null_bit;
+        n.m_value.p_map = nullptr;
+    }
+
+    static void boolean_scalar(BasicNodeType& n, const typename BasicNodeType::boolean_type b) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::bool_bit;
+        n.m_value.boolean = b;
+    }
+
+    static void integer_scalar(BasicNodeType& n, const typename BasicNodeType::integer_type i) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::int_bit;
+        n.m_value.integer = i;
+    }
+
+    /// @brief Constructs an INTEGER node from a uint64_t value that exceeds the signed range.
+    /// The raw bit pattern is stored in the integer field and the uint_bit flag is set so that
+    /// get_value<uint64_t>() / as_uint() can recover the original unsigned value.
+    static void unsigned_integer_scalar(BasicNodeType& n, const typename BasicNodeType::integer_type i) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::int_bit;
+        n.m_attrs |= node_attr_bits::uint_bit;
+        n.m_value.integer = i;
+    }
+
+    static void float_scalar(BasicNodeType& n, const typename BasicNodeType::float_number_type f) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::float_bit;
+        n.m_value.float_val = f;
+    }
+
+    template <typename... Args>
+    static void string_scalar(BasicNodeType& n, Args&&... args) {
+        destroy(n);
+        n.m_attrs |= node_attr_bits::string_bit;
+        n.m_value.p_str = create_object<typename BasicNodeType::string_type>(std::forward<Args>(args)...);
+    }
+
+private:
+    static void destroy(BasicNodeType& n) {
+        n.m_value.destroy(n.m_attrs & node_attr_mask::value);
+        // Clear both the value-type bits and the uint_bit style flag so that any
+        // subsequent reassignment starts from a clean state.
+        n.m_attrs &= ~(node_attr_mask::value | node_attr_bits::uint_bit);
+    }
+};
+
+/////////////////
+//   to_node   //
+/////////////////
+
+/// @brief to_node function for BasicNodeType::sequence_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A sequence node value type.
+/// @param n A basic_node object.
+/// @param s A sequence node value object.
+template <
+    typename BasicNodeType, typename T,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>,
+            std::is_same<typename BasicNodeType::sequence_type, remove_cvref_t<T>>>::value,
+        int> = 0>
+inline void to_node(BasicNodeType& n, T&& s) noexcept {
+    external_node_constructor<BasicNodeType>::sequence(n, std::forward<T>(s));
+}
+
+/// @brief to_node function for compatible sequence types.
+/// @note This overload is enabled when
+/// * both begin()/end() functions are callable on a `CompatSeqType` object
+/// * CompatSeqType doesn't have `mapped_type` (mapping-like type)
+/// * BasicNodeType::string_type cannot be constructed from a CompatSeqType object (string-like type)
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatSeqType A container type.
+/// @param n A basic_node object.
+/// @param s A container object.
+template <
+    typename BasicNodeType, typename CompatSeqType,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>,
+            negation<std::is_same<typename BasicNodeType::sequence_type, remove_cvref_t<CompatSeqType>>>,
+            negation<is_basic_node<CompatSeqType>>, detect::has_begin_end<CompatSeqType>,
+            negation<conjunction<detect::has_key_type<CompatSeqType>, detect::has_mapped_type<CompatSeqType>>>,
+            negation<std::is_constructible<typename BasicNodeType::string_type, CompatSeqType>>>::value,
+        int> = 0>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
+inline void to_node(BasicNodeType& n, CompatSeqType&& s) {
+    using std::begin;
+    using std::end;
+    external_node_constructor<BasicNodeType>::sequence(n, begin(s), end(s));
+}
+
+/// @brief to_node function for std::pair objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T The first type of std::pair.
+/// @tparam U The second type of std::pair.
+/// @param n A basic_node object.
+/// @param p A std::pair object.
+template <typename BasicNodeType, typename T, typename U>
+inline void to_node(BasicNodeType& n, const std::pair<T, U>& p) {
+    n = {p.first, p.second};
+}
+
+/// @brief concrete implementation of to_node function for std::tuple objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam ...Types The value types of std::tuple.
+/// @tparam ...Idx Index sequence values for std::tuple value types.
+/// @param n A basic_node object.
+/// @param t A std::tuple object.
+/// @param _ An index sequence. (unused)
+template <typename BasicNodeType, typename... Types, std::size_t... Idx>
+inline void to_node_tuple_impl(BasicNodeType& n, const std::tuple<Types...>& t, index_sequence<Idx...> /*unused*/) {
+    n = {std::get<Idx>(t)...};
+}
+
+/// @brief to_node function for std::tuple objects with no value types.
+/// @note This implementation is needed since calling `to_node_tuple_impl()` with an empty tuple creates a null node.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @param n A basic_node object.
+/// @param _ A std::tuple object. (unused)
+template <typename BasicNodeType>
+inline void to_node(BasicNodeType& n, const std::tuple<>& /*unused*/) {
+    n = BasicNodeType::sequence();
+}
+
+/// @brief to_node function for std::tuple objects with at least one value type.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam ...FirstType The first value types of std::tuple.
+/// @tparam ...RestTypes The rest value types of std::tuple. (maybe empty)
+/// @param n A basic_node object.
+/// @param t A std::tuple object.
+template <typename BasicNodeType, typename FirstType, typename... RestTypes>
+inline void to_node(BasicNodeType& n, const std::tuple<FirstType, RestTypes...>& t) {
+    to_node_tuple_impl(n, t, index_sequence_for<FirstType, RestTypes...> {});
+}
+
+/// @brief to_node function for BasicNodeType::mapping_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A mapping node value type.
+/// @param n A basic_node object.
+/// @param m A mapping node value object.
+template <
+    typename BasicNodeType, typename T,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>, std::is_same<typename BasicNodeType::mapping_type, remove_cvref_t<T>>>::value,
+        int> = 0>
+inline void to_node(BasicNodeType& n, T&& m) noexcept {
+    external_node_constructor<BasicNodeType>::mapping(n, std::forward<T>(m));
+}
+
+/// @brief to_node function for compatible mapping types.
+/// @note This overload is enabled when
+/// * both begin()/end() functions are callable on a `CompatMapType` object
+/// * CompatMapType has both `key_type` and `mapped_type`
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam CompatMapType A container type.
+/// @param n A basic_node object.
+/// @param m A container object.
+template <
+    typename BasicNodeType, typename CompatMapType,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatMapType>>,
+            negation<std::is_same<typename BasicNodeType::mapping_type, remove_cvref_t<CompatMapType>>>,
+            detect::has_begin_end<CompatMapType>, detect::has_key_type<CompatMapType>,
+            detect::has_mapped_type<CompatMapType>>::value,
+        int> = 0>
+inline void to_node(BasicNodeType& n, CompatMapType&& m) {
+    external_node_constructor<BasicNodeType>::mapping(n);
+    auto& map = n.as_map();
+    for (const auto& pair : std::forward<CompatMapType>(m)) {
+        map.emplace(pair.first, pair.second);
+    }
+}
+
+/// @brief to_node function for null objects.
+/// @tparam BasicNodeType A mapping node value type.
+/// @tparam NullType This must be std::nullptr_t type
+template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
+inline void to_node(BasicNodeType& n, std::nullptr_t /*unused*/) {
+    external_node_constructor<BasicNodeType>::null_scalar(n, nullptr);
+}
+
+/// @brief to_node function for BasicNodeType::boolean_type objects.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A boolean scalar node value type.
+/// @param n A basic_node object.
+/// @param b A boolean scalar node value object.
+template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
+inline void to_node(BasicNodeType& n, typename BasicNodeType::boolean_type b) noexcept {
+    external_node_constructor<BasicNodeType>::boolean_scalar(n, b);
+}
+
+/// @brief to_node function for integers.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T An integer type.
+/// @param n A basic_node object.
+/// @param i An integer object.
+template <
+    typename BasicNodeType, typename T,
+    enable_if_t<conjunction<is_basic_node<BasicNodeType>, is_non_bool_integral<T>>::value, int> = 0>
+inline void to_node(BasicNodeType& n, T i) noexcept {
+    external_node_constructor<BasicNodeType>::integer_scalar(n, i);
+}
+
+/// @brief to_node function for floating point numbers.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A floating point number type.
+/// @param n A basic_node object.
+/// @param f A floating point number object.
+template <
+    typename BasicNodeType, typename T,
+    enable_if_t<conjunction<is_basic_node<BasicNodeType>, std::is_floating_point<T>>::value, int> = 0>
+inline void to_node(BasicNodeType& n, T f) noexcept {
+    external_node_constructor<BasicNodeType>::float_scalar(n, f);
+}
+
+/// @brief to_node function for compatible strings.
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam T A compatible string type.
+/// @param n A basic_node object.
+/// @param s A compatible string object.
+template <
+    typename BasicNodeType, typename T,
+    enable_if_t<
+        conjunction<
+            is_basic_node<BasicNodeType>, negation<is_null_pointer<T>>,
+            std::is_constructible<typename BasicNodeType::string_type, T>>::value,
+        int> = 0>
+inline void to_node(BasicNodeType& n, T&& s) {
+    external_node_constructor<BasicNodeType>::string_scalar(n, std::forward<T>(s));
+}
+
+/// @brief A function object to call to_node functions.
+/// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
+struct to_node_fn {
+    /// @brief Call to_node function suitable for the given T type.
+    /// @tparam BasicNodeType A basic_node template instance type.
+    /// @tparam T A target value type assigned to the basic_node object.
+    /// @param n A basic_node object.
+    /// @param val A target object assigned to the basic_node object.
+    /// @return decltype(to_node(n, std::forward<T>(val))) void by default. User can set it to some other type.
+    template <typename BasicNodeType, typename T>
+    auto operator()(BasicNodeType& n, T&& val) const
+        noexcept(noexcept(to_node(n, std::forward<T>(val)))) -> decltype(to_node(n, std::forward<T>(val))) {
+        return to_node(n, std::forward<T>(val));
+    }
+};
+
+FK_YAML_DETAIL_NAMESPACE_END
+
+FK_YAML_NAMESPACE_BEGIN
+
+#ifndef FK_YAML_HAS_CXX_17
+// anonymous namespace to hold `to_node` functor.
+// see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html for why it's needed.
+namespace // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-namespaces)
+{
+#endif
+
+/// @brief A global object to represent ADL friendly to_node functor.
+// NOLINTNEXTLINE(misc-definitions-in-headers)
+FK_YAML_INLINE_VAR constexpr const auto& to_node = detail::static_const<detail::to_node_fn>::value;
+
+#ifndef FK_YAML_HAS_CXX_17
+} // namespace
+#endif
+
+FK_YAML_NAMESPACE_END
+
+#endif /* FK_YAML_DETAIL_CONVERSIONS_TO_NODE_HPP */
+
 // #include <fkYAML/detail/encodings/yaml_escaper.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ENCODINGS_YAML_ESCAPER_HPP
@@ -5722,10 +6216,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/scalar_scanner.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_SCALAR_SCANNER_HPP
@@ -6058,10 +6552,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/tag_t.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_TAG_T_HPP
@@ -6615,6 +7109,24 @@ private:
             if FK_YAML_LIKELY (converted) {
                 return basic_node_type(integer);
             }
+
+            // For untagged plain integer scalars, attempt a uint64_t parse to handle large
+            // positive values that exceed int64_t max (e.g. xxHash/UUID results like
+            // 15745692345339290292). This only applies when integer_type is a signed 64-bit
+            // type; any other width would not be able to represent the value anyway.
+            if (tag_type != tag_t::INTEGER && std::is_signed<integer_type>::value &&
+                sizeof(integer_type) == sizeof(uint64_t)) {
+                uint64_t u64 = 0;
+                if (detail::atoi(token.begin(), token.end(), u64)) {
+                    basic_node_type node;
+                    // Store the bit pattern in the signed field and set uint_bit so that
+                    // as_uint() / get_value<uint64_t>() can recover the correct value.
+                    detail::external_node_constructor<basic_node_type>::unsigned_integer_scalar(
+                        node, static_cast<integer_type>(u64));
+                    return node;
+                }
+            }
+
             if FK_YAML_UNLIKELY (tag_type == tag_t::INTEGER) {
                 throw parse_error("Failed to convert a scalar to an integer.", m_line, m_indent);
             }
@@ -6665,10 +7177,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/tag_resolver.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_TAG_RESOLVER_HPP
@@ -6860,10 +7372,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/meta/input_adapter_traits.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_META_INPUT_ADAPTER_TRAITS_HPP
@@ -6920,153 +7432,14 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/meta/stl_supplement.hpp>
 
 // #include <fkYAML/detail/node_attrs.hpp>
-//  _______   __ __   __  _____   __  __  __
-// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
-// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
-//
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
-// SPDX-License-Identifier: MIT
-
-#ifndef FK_YAML_DETAIL_NODE_ATTRS_HPP
-#define FK_YAML_DETAIL_NODE_ATTRS_HPP
-
-#include <cstdint>
-#include <limits>
-
-// #include <fkYAML/detail/macros/define_macros.hpp>
-
-// #include <fkYAML/node_type.hpp>
-
-
-FK_YAML_DETAIL_NAMESPACE_BEGIN
-
-/// @brief The type for node attribute bits.
-using node_attr_t = uint32_t;
-
-/// @brief The namespace to define bit masks for node attribute bits.
-namespace node_attr_mask {
-
-/// The bit mask for node value type bits.
-constexpr node_attr_t value = 0x0000FFFFu;
-/// The bit mask for node style type bits. (bits are not yet defined.)
-constexpr node_attr_t style = 0x00FF0000u;
-/// The bit mask for node property related bits.
-constexpr node_attr_t props = 0xFF000000u;
-/// The bit mask for anchor/alias node type bits.
-constexpr node_attr_t anchoring = 0x03000000u;
-/// The bit mask for anchor offset value bits.
-constexpr node_attr_t anchor_offset = 0xFC000000u;
-/// The bit mask for all the bits for node attributes.
-constexpr node_attr_t all = std::numeric_limits<node_attr_t>::max();
-
-} // namespace node_attr_mask
-
-/// @brief The namespace to define bits for node attributes.
-namespace node_attr_bits {
-
-/// The sequence node bit.
-constexpr node_attr_t seq_bit = 1u << 0;
-/// The mapping node bit.
-constexpr node_attr_t map_bit = 1u << 1;
-/// The null scalar node bit.
-constexpr node_attr_t null_bit = 1u << 2;
-/// The boolean scalar node bit.
-constexpr node_attr_t bool_bit = 1u << 3;
-/// The integer scalar node bit.
-constexpr node_attr_t int_bit = 1u << 4;
-/// The floating point scalar node bit.
-constexpr node_attr_t float_bit = 1u << 5;
-/// The string scalar node bit.
-constexpr node_attr_t string_bit = 1u << 6;
-
-/// A utility bit set to filter scalar node bits.
-constexpr node_attr_t scalar_bits = null_bit | bool_bit | int_bit | float_bit | string_bit;
-
-/// The anchor node bit.
-constexpr node_attr_t anchor_bit = 0x01000000u;
-/// The alias node bit.
-constexpr node_attr_t alias_bit = 0x02000000u;
-
-/// A utility bit set for initialization.
-constexpr node_attr_t default_bits = null_bit;
-
-/// @brief Converts a node_type value to a node_attr_t value.
-/// @param t A type of node value.
-/// @return The associated node value bit.
-inline node_attr_t from_node_type(node_type t) noexcept {
-    switch (t) {
-    case node_type::SEQUENCE:
-        return seq_bit;
-    case node_type::MAPPING:
-        return map_bit;
-    case node_type::NULL_OBJECT:
-        return null_bit;
-    case node_type::BOOLEAN:
-        return bool_bit;
-    case node_type::INTEGER:
-        return int_bit;
-    case node_type::FLOAT:
-        return float_bit;
-    case node_type::STRING:
-        return string_bit;
-    default:                        // LCOV_EXCL_LINE
-        return node_attr_mask::all; // LCOV_EXCL_LINE
-    }
-}
-
-/// @brief Converts a node_attr_t value to a node_type value.
-/// @param bits node attribute bits
-/// @return An associated node value type with the given node value bit.
-inline node_type to_node_type(node_attr_t bits) noexcept {
-    switch (bits & node_attr_mask::value) {
-    case seq_bit:
-        return node_type::SEQUENCE;
-    case map_bit:
-        return node_type::MAPPING;
-    case null_bit:
-        return node_type::NULL_OBJECT;
-    case bool_bit:
-        return node_type::BOOLEAN;
-    case int_bit:
-        return node_type::INTEGER;
-    case float_bit:
-        return node_type::FLOAT;
-    case string_bit:
-        return node_type::STRING;
-    default:                   // LCOV_EXCL_LINE
-        detail::unreachable(); // LCOV_EXCL_LINE
-    }
-}
-
-/// @brief Get an anchor offset used to reference an anchor node from the given attribute bits.
-/// @param attrs node attribute bits
-/// @return An anchor offset value.
-inline uint32_t get_anchor_offset(node_attr_t attrs) noexcept {
-    return (attrs & node_attr_mask::anchor_offset) >> 26;
-}
-
-/// @brief Set an anchor offset value to the appropriate bits.
-/// @param offset An anchor offset value.
-/// @param attrs node attribute bit set into which the offset value is written.
-inline void set_anchor_offset(uint32_t offset, node_attr_t& attrs) noexcept {
-    attrs &= ~node_attr_mask::anchor_offset;
-    attrs |= (offset & 0x3Fu) << 26;
-}
-
-} // namespace node_attr_bits
-
-FK_YAML_DETAIL_NAMESPACE_END
-
-#endif /* FK_YAML_DETAIL_NODE_ATTRS_HPP */
 
 // #include <fkYAML/detail/node_property.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_NODE_PROPERTY_HPP
@@ -7133,11 +7506,15 @@ class basic_deserializer {
     };
 
     /// @brief Context information set for parsing.
+    /// @note
+    /// A context either borrows a node which the result tree already owns, or owns a node of its own until that
+    /// node is grafted into the tree. Ownership is held by the owned_node member rather than derived from the
+    /// state member, which the parsing code rewrites while a node is still owned.
     struct parse_context {
         /// @brief Construct a new parse_context object.
         parse_context() = default;
 
-        /// @brief Construct a new parse_context object with non-default values for each parameter.
+        /// @brief Construct a new parse_context object which borrows a node owned by the result tree.
         /// @param line The current line. (count from zero)
         /// @param indent The indentation width in the current line. (count from zero)
         /// @param state The parse context type.
@@ -7149,23 +7526,26 @@ class basic_deserializer {
               p_node(p_node) {
         }
 
-        parse_context(const parse_context&) noexcept = default;
-        parse_context& operator=(const parse_context&) noexcept = default;
+        /// @brief Construct a new parse_context object which owns its node.
+        /// @param line The current line. (count from zero)
+        /// @param indent The indentation width in the current line. (count from zero)
+        /// @param state The parse context type.
+        /// @param node The node owned by this context.
+        parse_context(
+            uint32_t line, uint32_t indent, context_state_t state, std::unique_ptr<basic_node_type> node) noexcept
+            : line(line),
+              indent(indent),
+              state(state),
+              p_node(node.get()),
+              owned_node(std::move(node)) {
+        }
+
+        // Parse contexts are move-only so that the ownership of an owned node cannot be duplicated.
+        parse_context(const parse_context&) = delete;
+        parse_context& operator=(const parse_context&) = delete;
         parse_context(parse_context&&) noexcept = default;
         parse_context& operator=(parse_context&&) noexcept = default;
-
-        ~parse_context() {
-            switch (state) {
-            case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
-            case context_state_t::FLOW_SEQUENCE_KEY:
-            case context_state_t::FLOW_MAPPING_KEY:
-                delete p_node;
-                p_node = nullptr;
-                break;
-            default:
-                break;
-            }
-        }
+        ~parse_context() = default;
 
         /// The current line. (count from zero)
         uint32_t line {0};
@@ -7175,6 +7555,8 @@ class basic_deserializer {
         context_state_t state {context_state_t::BLOCK_MAPPING};
         /// The pointer to the associated node to this context.
         basic_node_type* p_node {nullptr};
+        /// The node owned by this context, if any. Empty if p_node is owned by the result tree.
+        std::unique_ptr<basic_node_type> owned_node {};
     };
 
     /// @brief Definitions of state types for expected flow token hints.
@@ -7255,15 +7637,13 @@ private:
                 apply_node_properties(root);
             }
 
-            parse_context context(
-                lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_SEQUENCE, &root);
-            m_context_stack.emplace_back(context);
+            const uint32_t seq_line = lexer.get_lines_processed();
+            const uint32_t seq_indent = lexer.get_last_token_begin_pos();
+            m_context_stack.emplace_back(seq_line, seq_indent, context_state_t::BLOCK_SEQUENCE, &root);
 
             mp_current_node = &(root.as_seq().back());
             apply_directive_set(*mp_current_node);
-            context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
-            context.p_node = mp_current_node;
-            m_context_stack.emplace_back(std::move(context));
+            m_context_stack.emplace_back(seq_line, seq_indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
 
             token = lexer.get_next_token();
             line = lexer.get_lines_processed();
@@ -7308,6 +7688,17 @@ private:
             indent = lexer.get_last_token_begin_pos();
             break;
         }
+        case lexical_token_t::KEY_SEPARATOR:
+            root = basic_node_type::mapping();
+            apply_directive_set(root);
+            apply_node_properties(root);
+            m_context_stack.emplace_back(
+                lexer.get_lines_processed(), lexer.get_last_token_begin_pos(), context_state_t::BLOCK_MAPPING, &root);
+            add_new_key(basic_node_type(""), line, indent);
+            token = lexer.get_next_token();
+            line = lexer.get_lines_processed();
+            indent = lexer.get_last_token_begin_pos();
+            break;
         case lexical_token_t::BLOCK_LITERAL_SCALAR:
         case lexical_token_t::BLOCK_FOLDED_SCALAR:
             // If a block scalar token is detected here, current document contains single scalar.
@@ -7348,6 +7739,13 @@ private:
         FK_YAML_ASSERT(
             last_type == lexical_token_t::END_OF_BUFFER || last_type == lexical_token_t::END_OF_DIRECTIVES ||
             last_type == lexical_token_t::END_OF_DOCUMENT);
+
+        // An explicit key at the end of a document has no value either.
+        // ```yaml
+        // ? foo
+        // # -> {foo: null}
+        // ```
+        add_explicit_key_with_null_value();
 
         // reset parameters for the next call.
         mp_current_node = nullptr;
@@ -7466,6 +7864,15 @@ private:
         do {
             switch (token.type) {
             case lexical_token_t::EXPLICIT_KEY_PREFIX: {
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("An explicit key is not allowed in this context.", line, indent);
+                }
+
+                if (indent == m_context_stack.back().indent) {
+                    // The preceding explicit key, if any, has no value at this point.
+                    add_explicit_key_with_null_value();
+                }
+
                 const bool needs_to_move_back = indent == 0 || indent < m_context_stack.back().indent;
                 if (needs_to_move_back) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {
@@ -7497,31 +7904,32 @@ private:
 
                 token = lexer.get_next_token();
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
-                    // heap-allocated node will be freed in handling the corresponding KEY_SEPARATOR event
-                    auto* p_node = new basic_node_type(node_type::SEQUENCE);
-                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_KEY, p_node);
+                    // The key node is owned by its context until the corresponding KEY_SEPARATOR event.
+                    std::unique_ptr<basic_node_type> key_node(new basic_node_type(node_type::SEQUENCE));
+                    basic_node_type* p_node = key_node.get();
+                    m_context_stack.emplace_back(
+                        line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_KEY, std::move(key_node));
 
                     apply_directive_set(*p_node);
-                    parse_context context(
-                        lexer.get_lines_processed(),
-                        lexer.get_last_token_begin_pos(),
-                        context_state_t::BLOCK_SEQUENCE,
-                        p_node);
-                    m_context_stack.emplace_back(context);
+                    const uint32_t seq_line = lexer.get_lines_processed();
+                    const uint32_t seq_indent = lexer.get_last_token_begin_pos();
+                    m_context_stack.emplace_back(seq_line, seq_indent, context_state_t::BLOCK_SEQUENCE, p_node);
 
                     p_node->as_seq().emplace_back(basic_node_type());
                     mp_current_node = &(p_node->as_seq().back());
                     apply_directive_set(*mp_current_node);
-                    context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
-                    context.p_node = mp_current_node;
-                    m_context_stack.emplace_back(std::move(context));
+                    m_context_stack.emplace_back(
+                        seq_line, seq_indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
 
                     break;
                 }
 
-                // heap-allocated node will be freed in handling the corresponding KEY_SEPARATOR event
+                // The key node is owned by its context until the corresponding KEY_SEPARATOR event.
                 m_context_stack.emplace_back(
-                    line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_KEY, new basic_node_type());
+                    line,
+                    indent,
+                    context_state_t::BLOCK_MAPPING_EXPLICIT_KEY,
+                    std::unique_ptr<basic_node_type>(new basic_node_type()));
                 mp_current_node = m_context_stack.back().p_node;
                 apply_directive_set(*mp_current_node);
                 indent = lexer.get_last_token_begin_pos();
@@ -7530,13 +7938,15 @@ private:
                 continue;
             }
             case lexical_token_t::KEY_SEPARATOR: {
-                FK_YAML_ASSERT(!m_context_stack.empty());
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("A key separator is not allowed in this context.", line, indent);
+                }
                 if FK_YAML_UNLIKELY (m_context_stack.back().state == context_state_t::BLOCK_SEQUENCE_ENTRY) {
                     // empty mapping keys are not supported.
                     // ```yaml
                     // - : foo
                     // ```
-                    throw parse_error("sequence key should not be empty.", line, indent);
+                    throw parse_error("mapping key should not be empty.", line, indent);
                 }
 
                 if (m_flow_context_depth > 0) {
@@ -7568,6 +7978,21 @@ private:
                 }
 
                 if (line > old_line) {
+                    const bool is_explicit_value_begin =
+                        m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY &&
+                        (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX ||
+                         indent > m_context_stack.back().indent);
+                    if (is_explicit_value_begin) {
+                        // The value of an explicit key can begin on a line after its key separator.
+                        // ```yaml
+                        // ? foo
+                        // :
+                        //   bar
+                        // # -> {foo: bar}
+                        // ```
+                        add_explicit_key_with_empty_value(old_line, old_indent);
+                    }
+
                     if (m_needs_tag_impl) {
                         const tag_t tag_type = tag_resolver_type::resolve_tag(m_tag_name, mp_meta);
                         if (tag_type == tag_t::MAPPING || tag_type == tag_t::CUSTOM_TAG) {
@@ -7600,10 +8025,8 @@ private:
 
                         mp_current_node = &(mp_current_node->as_seq().back());
                         apply_directive_set(*mp_current_node);
-                        parse_context entry_context = cur_context;
-                        entry_context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
-                        entry_context.p_node = mp_current_node;
-                        m_context_stack.emplace_back(std::move(entry_context));
+                        m_context_stack.emplace_back(
+                            line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
 
                         token = lexer.get_next_token();
                         line = lexer.get_lines_processed();
@@ -7640,19 +8063,38 @@ private:
                     }
 
                     if (indent <= m_context_stack.back().indent) {
-                        FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::MAPPING_VALUE);
-
-                        // Mapping values can be omitted and are considered to be null.
+                        // An explicit key can omit its value as well, in which case the entry must still be
+                        // added to the parent mapping.
                         // ```yaml
-                        // foo:
-                        // bar:
-                        //   baz:
-                        // qux:
-                        // # -> {foo: null, bar: {baz: null}, qux: null}
+                        // ? foo
+                        // :
+                        // bar: baz
+                        // # -> {foo: null, bar: baz}
                         // ```
-                        pop_to_parent_node(line, indent, [indent](const parse_context& c) {
-                            return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
-                        });
+                        const bool is_entry_added = add_explicit_key_with_null_value();
+                        if (!is_entry_added) {
+                            if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::MAPPING_VALUE) {
+                                // The key separator does not follow a mapping key, for example:
+                                // ```yaml
+                                // ? foo
+                                // :
+                                // :
+                                // ```
+                                throw parse_error("A key separator is not allowed in this context.", line, indent);
+                            }
+
+                            // Mapping values can be omitted and are considered to be null.
+                            // ```yaml
+                            // foo:
+                            // bar:
+                            //   baz:
+                            // qux:
+                            // # -> {foo: null, bar: {baz: null}, qux: null}
+                            // ```
+                            pop_to_parent_node(line, indent, [indent](const parse_context& c) {
+                                return (c.state == context_state_t::BLOCK_MAPPING) && (indent == c.indent);
+                            });
+                        }
                     }
 
                     // defer checking the existence of a key separator after the following scalar until the next
@@ -7661,14 +8103,11 @@ private:
                 }
 
                 // handle explicit mapping key separators.
-                FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+                if FK_YAML_UNLIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
+                    throw parse_error("Unexpected explicit mapping key separator is found.", line, indent);
+                }
 
-                basic_node_type key_node = std::move(*m_context_stack.back().p_node);
-                m_context_stack.pop_back();
-                m_context_stack.back().p_node->as_map().emplace(key_node, basic_node_type());
-                mp_current_node = &(m_context_stack.back().p_node->operator[](std::move(key_node)));
-                m_context_stack.emplace_back(
-                    old_line, old_indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+                add_explicit_key_with_empty_value(old_line, old_indent);
 
                 if (token.type == lexical_token_t::SEQUENCE_BLOCK_PREFIX) {
                     *mp_current_node = basic_node_type::sequence({basic_node_type()});
@@ -7677,10 +8116,7 @@ private:
                     m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE, mp_current_node);
 
                     mp_current_node = &(mp_current_node->as_seq().back());
-                    parse_context entry_context = m_context_stack.back();
-                    entry_context.state = context_state_t::BLOCK_SEQUENCE_ENTRY;
-                    entry_context.p_node = mp_current_node;
-                    m_context_stack.emplace_back(std::move(entry_context));
+                    m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_SEQUENCE_ENTRY, mp_current_node);
                     break;
                 }
 
@@ -7700,7 +8136,9 @@ private:
                 // ```
                 continue;
             case lexical_token_t::SEQUENCE_BLOCK_PREFIX: {
-                FK_YAML_ASSERT(!m_context_stack.empty());
+                if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                    throw parse_error("invalid block sequence entry is found.", line, indent);
+                }
                 const uint32_t parent_indent = m_context_stack.back().indent;
                 if (indent == parent_indent) {
                     // If the previous block sequence entry is empty, just move to the parent context.
@@ -7748,6 +8186,10 @@ private:
                 if (m_flow_context_depth == 0) {
                     lexer.set_context_state(true);
 
+                    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                        throw parse_error("invalid flow sequence beginning is found.", line, indent);
+                    }
+
                     if (indent <= m_context_stack.back().indent) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                             switch (c.state) {
@@ -7766,7 +8208,7 @@ private:
 
                 ++m_flow_context_depth;
 
-                switch (m_context_stack.back().state) {
+                switch (current_context(line, indent).state) {
                 case context_state_t::BLOCK_SEQUENCE:
                 case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->as_seq().emplace_back(basic_node_type::sequence());
@@ -7775,9 +8217,12 @@ private:
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
-                    // heap-allocated node will be freed in handling the corresponding SEQUENCE_FLOW_END event.
+                    // The key node is owned by its context until the corresponding SEQUENCE_FLOW_END event.
                     m_context_stack.emplace_back(
-                        line, indent, context_state_t::FLOW_SEQUENCE_KEY, new basic_node_type(node_type::SEQUENCE));
+                        line,
+                        indent,
+                        context_state_t::FLOW_SEQUENCE_KEY,
+                        std::unique_ptr<basic_node_type>(new basic_node_type(node_type::SEQUENCE)));
                     mp_current_node = m_context_stack.back().p_node;
                     break;
                 default: {
@@ -7804,38 +8249,27 @@ private:
                     lexer.set_context_state(false);
                 }
 
-                // find the corresponding flow sequence beginning.
-                auto itr = std::find_if( // LCOV_EXCL_LINE
-                    m_context_stack.rbegin(),
-                    m_context_stack.rend(),
-                    [](const parse_context& c) {
-                        switch (c.state) {
-                        case context_state_t::FLOW_SEQUENCE_KEY:
-                        case context_state_t::FLOW_SEQUENCE:
-                            return true;
-                        default:
-                            return false;
-                        }
-                    });
-
-                const bool is_valid = itr != m_context_stack.rend();
-                if FK_YAML_UNLIKELY (!is_valid) {
+                const bool has_valid_beginning =
+                    !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_SEQUENCE ||
+                                                 m_context_stack.back().state == context_state_t::FLOW_SEQUENCE_KEY);
+                if FK_YAML_UNLIKELY (!has_valid_beginning) {
                     throw parse_error("No corresponding flow sequence beginning is found.", line, indent);
                 }
 
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
-                last_context.p_node = nullptr;
                 indent = last_context.indent;
-                const context_state_t state = last_context.state;
+                // The node stays alive until its value is either moved into the tree below or dropped here.
+                std::unique_ptr<basic_node_type> owned_node = std::move(last_context.owned_node);
                 m_context_stack.pop_back();
 
-                // handle cases where the flow sequence is a mapping key node.
+                // handle cases where the flow sequence is a mapping key node. A context owns its node only
+                // while that node is a key which has not been added to its parent mapping yet.
 
-                if (!m_context_stack.empty() && state == context_state_t::FLOW_SEQUENCE_KEY) {
-                    basic_node_type key_node = std::move(*mp_current_node);
-                    delete mp_current_node;
+                if (!m_context_stack.empty() && owned_node != nullptr) {
+                    basic_node_type key_node = std::move(*owned_node);
+                    owned_node.reset();
                     mp_current_node = m_context_stack.back().p_node;
                     m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
 
@@ -7871,6 +8305,10 @@ private:
                 if (m_flow_context_depth == 0) {
                     lexer.set_context_state(true);
 
+                    if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                        throw parse_error("invalid flow mapping beginning is found.", line, indent);
+                    }
+
                     if (indent <= m_context_stack.back().indent) {
                         pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                             switch (c.state) {
@@ -7889,7 +8327,7 @@ private:
 
                 ++m_flow_context_depth;
 
-                switch (m_context_stack.back().state) {
+                switch (current_context(line, indent).state) {
                 case context_state_t::BLOCK_SEQUENCE:
                 case context_state_t::FLOW_SEQUENCE:
                     mp_current_node->as_seq().emplace_back(basic_node_type::mapping());
@@ -7898,9 +8336,12 @@ private:
                     break;
                 case context_state_t::BLOCK_MAPPING:
                 case context_state_t::FLOW_MAPPING:
-                    // heap-allocated node will be freed in handling the corresponding MAPPING_FLOW_END event.
+                    // The key node is owned by its context until the corresponding MAPPING_FLOW_END event.
                     m_context_stack.emplace_back(
-                        line, indent, context_state_t::FLOW_MAPPING_KEY, new basic_node_type(node_type::MAPPING));
+                        line,
+                        indent,
+                        context_state_t::FLOW_MAPPING_KEY,
+                        std::unique_ptr<basic_node_type>(new basic_node_type(node_type::MAPPING)));
                     mp_current_node = m_context_stack.back().p_node;
                     break;
                 default: {
@@ -7930,38 +8371,27 @@ private:
                     lexer.set_context_state(false);
                 }
 
-                // find the corresponding flow mapping beginning.
-                auto itr = std::find_if( // LCOV_EXCL_LINE
-                    m_context_stack.rbegin(),
-                    m_context_stack.rend(),
-                    [](const parse_context& c) {
-                        switch (c.state) {
-                        case context_state_t::FLOW_MAPPING_KEY:
-                        case context_state_t::FLOW_MAPPING:
-                            return true;
-                        default:
-                            return false;
-                        }
-                    });
-
-                const bool is_valid = itr != m_context_stack.rend();
-                if FK_YAML_UNLIKELY (!is_valid) {
+                const bool has_valid_beginning =
+                    !m_context_stack.empty() && (m_context_stack.back().state == context_state_t::FLOW_MAPPING ||
+                                                 m_context_stack.back().state == context_state_t::FLOW_MAPPING_KEY);
+                if FK_YAML_UNLIKELY (!has_valid_beginning) {
                     throw parse_error("No corresponding flow mapping beginning is found.", line, indent);
                 }
 
                 // keep the last state for later processing.
                 parse_context& last_context = m_context_stack.back();
                 mp_current_node = last_context.p_node;
-                last_context.p_node = nullptr;
                 indent = last_context.indent;
-                const context_state_t state = last_context.state;
+                // The node stays alive until its value is either moved into the tree below or dropped here.
+                std::unique_ptr<basic_node_type> owned_node = std::move(last_context.owned_node);
                 m_context_stack.pop_back();
 
-                // handle cases where the flow mapping is a mapping key node.
+                // handle cases where the flow mapping is a mapping key node. A context owns its node only
+                // while that node is a key which has not been added to its parent mapping yet.
 
-                if (!m_context_stack.empty() && state == context_state_t::FLOW_MAPPING_KEY) {
-                    basic_node_type key_node = std::move(*mp_current_node);
-                    delete mp_current_node;
+                if (!m_context_stack.empty() && owned_node != nullptr) {
+                    basic_node_type key_node = std::move(*owned_node);
+                    owned_node.reset();
                     mp_current_node = m_context_stack.back().p_node;
                     m_flow_token_state = flow_token_state_t::NEEDS_VALUE_OR_SUFFIX;
 
@@ -7994,7 +8424,9 @@ private:
                 continue;
             }
             case lexical_token_t::VALUE_SEPARATOR:
-                FK_YAML_ASSERT(m_flow_context_depth > 0);
+                if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
+                    throw parse_error("invalid value separator is found.", line, indent);
+                }
                 if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX) {
                     throw parse_error("invalid value separator is found.", line, indent);
                 }
@@ -8010,22 +8442,34 @@ private:
                     throw parse_error("Anchor cannot be specified to an alias node.", line, indent);
                 }
 
-                std::string token_str = std::string(token.str.begin(), token.str.end());
+                const std::string anchor_name = std::string(token.str.begin(), token.str.end());
 
-                const auto anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(token_str));
+                const auto anchor_counts = static_cast<uint32_t>(mp_meta->anchor_table.count(anchor_name));
                 if FK_YAML_UNLIKELY (anchor_counts == 0) {
                     throw parse_error("The given anchor name must appear prior to the alias node.", line, indent);
                 }
 
                 basic_node_type node {};
                 node.m_attrs |= detail::node_attr_bits::alias_bit;
-                node.m_prop.anchor = std::move(token_str);
+                node.m_prop.anchor = anchor_name;
                 detail::node_attr_bits::set_anchor_offset(anchor_counts - 1, node.m_attrs);
 
                 apply_directive_set(node);
                 apply_node_properties(node);
 
                 deserialize_scalar(lexer, std::move(node), indent, line, token);
+
+                // Check if the alias node is self-referential.
+                // If so, throw a parse error to avoid infinite recursion and stack overflow during deserialization.
+                auto itr = mp_meta->anchor_table.equal_range(anchor_name).first;
+                std::advance(itr, anchor_counts - 1);
+                const auto& anchor = itr->second;
+                const bool is_self_referential = anchor.contains_self_referential_alias(anchor_name, anchor_counts - 1);
+                if FK_YAML_UNLIKELY (is_self_referential) {
+                    const std::string msg = format("Self-referential alias (*%s) is found.", anchor_name.c_str());
+                    throw parse_error(msg.c_str(), line, indent);
+                }
+
                 continue;
             }
             case lexical_token_t::PLAIN_SCALAR:
@@ -8162,6 +8606,9 @@ private:
     /// @param indent The indentation width in the current line where the key is found.
     void add_new_key(basic_node_type&& key, const uint32_t line, const uint32_t indent) {
         if (m_flow_context_depth == 0) {
+            if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+                throw parse_error("A mapping key is not allowed in this context.", line, indent);
+            }
             if FK_YAML_UNLIKELY (m_context_stack.back().indent < indent) {
                 // bad indentation like the following YAML:
                 // ```yaml
@@ -8194,7 +8641,7 @@ private:
         }
 
         mp_current_node = &(itr.first->second);
-        const parse_context& key_context = m_context_stack.back();
+        const parse_context& key_context = current_context(line, indent);
         m_context_stack.emplace_back(
             key_context.line, key_context.indent, context_state_t::MAPPING_VALUE, mp_current_node);
     }
@@ -8203,7 +8650,9 @@ private:
     /// @param node_value A rvalue basic_node_type object to be assigned to the current node.
     void assign_node_value(basic_node_type&& node_value, const uint32_t line, const uint32_t indent) {
         if (mp_current_node->is_sequence()) {
-            FK_YAML_ASSERT(m_flow_context_depth > 0);
+            if FK_YAML_UNLIKELY (m_flow_context_depth == 0) {
+                throw parse_error("invalid block sequence entry is found.", line, indent);
+            }
 
             if FK_YAML_UNLIKELY (m_flow_token_state != flow_token_state_t::NEEDS_VALUE_OR_SUFFIX) {
                 // Flow sequence entries are not allowed to be empty.
@@ -8227,7 +8676,7 @@ private:
 
         if FK_YAML_LIKELY (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
             m_context_stack.pop_back();
-            mp_current_node = m_context_stack.back().p_node;
+            mp_current_node = current_context(line, indent).p_node;
 
             if (m_flow_context_depth > 0) {
                 m_flow_token_state = flow_token_state_t::NEEDS_SEPARATOR_OR_SUFFIX;
@@ -8268,6 +8717,10 @@ private:
                 indent = lexer.get_last_token_begin_pos();
                 line = lexer.get_lines_processed();
 
+                if (m_context_stack.empty()) {
+                    throw parse_error("invalid explicit mapping key separator is found.", line, indent);
+                }
+
                 if (m_context_stack.back().state != context_state_t::BLOCK_MAPPING_EXPLICIT_KEY) {
                     pop_to_parent_node(line, indent, [indent](const parse_context& c) {
                         return c.state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY && indent == c.indent;
@@ -8281,6 +8734,22 @@ private:
                     parse_context& cur_context = m_context_stack.back();
                     switch (cur_context.state) {
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_KEY:
+                        if (cur_context.indent == indent) {
+                            // A mapping entry which follows an explicit key without its value, for example:
+                            // ```yaml
+                            // ? foo
+                            // bar: 123
+                            // # -> {foo: null, bar: 123}
+                            // ```
+                            add_explicit_key_with_null_value();
+                            add_new_key(std::move(node), line, indent);
+                            indent = lexer.get_last_token_begin_pos();
+                            line = lexer.get_lines_processed();
+                            return;
+                        }
+
+                        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
+                        break;
                     case context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE:
                         m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING, mp_current_node);
                         break;
@@ -8348,13 +8817,74 @@ private:
         line = lexer.get_lines_processed();
     }
 
+    /// @brief Returns the parse context on the top of the context stack.
+    /// @note
+    /// Accessing an empty context stack is undefined behavior, so the emptiness is checked before the access.
+    /// No known input reaches the throw now that a parse context owns its key node, which is why it is left out
+    /// of the coverage measurement. The check stays because the alternative for a caller is dereferencing an
+    /// invalid iterator.
+    /// @param line The current line count.
+    /// @param indent The current indentation width.
+    /// @return The parse context on the top of the context stack.
+    parse_context& current_context(const uint32_t line, const uint32_t indent) {
+        // LCOV_EXCL_START
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent context is found.", line, indent);
+        }
+        // LCOV_EXCL_STOP
+        return m_context_stack.back();
+    }
+
+    /// @brief Adds an entry for an explicit key and makes its value node the current node.
+    /// @note The current context must be the context of the explicit key.
+    /// @param line The line where the value of the explicit key begins.
+    /// @param indent The indentation width where the value of the explicit key begins.
+    void add_explicit_key_with_empty_value(const uint32_t line, const uint32_t indent) {
+        FK_YAML_ASSERT(m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY);
+
+        basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+        m_context_stack.pop_back();
+        basic_node_type* p_parent_node = current_context(line, indent).p_node;
+        p_parent_node->as_map().emplace(key_node, basic_node_type());
+        mp_current_node = &(p_parent_node->operator[](std::move(key_node)));
+        m_context_stack.emplace_back(line, indent, context_state_t::BLOCK_MAPPING_EXPLICIT_VALUE, mp_current_node);
+    }
+
+    /// @brief Adds an entry with a null value for an explicit key which is not followed by its value.
+    /// @note
+    /// An explicit key is kept in its own context until its value is found. If no value follows the key, the
+    /// entry must still be added to the parent mapping since an omitted value is a null value.
+    /// ```yaml
+    /// ? foo
+    /// ? bar
+    /// # -> {foo: null, bar: null}
+    /// ```
+    /// @return true if an entry has been added, false if the current context is not an explicit key.
+    bool add_explicit_key_with_null_value() {
+        const bool is_explicit_key =
+            m_context_stack.size() > 1 && m_context_stack.back().state == context_state_t::BLOCK_MAPPING_EXPLICIT_KEY;
+        if (!is_explicit_key) {
+            return false;
+        }
+
+        basic_node_type key_node = std::move(*m_context_stack.back().p_node);
+        m_context_stack.pop_back();
+        m_context_stack.back().p_node->as_map().emplace(std::move(key_node), basic_node_type());
+        mp_current_node = m_context_stack.back().p_node;
+        return true;
+    }
+
     /// @brief Pops parent contexts to a block mapping with the given indentation.
     /// @tparam Pred Functor type to test parent contexts.
     /// @param line The current line count.
     /// @param indent The indentation level of the target parent block mapping.
     template <typename Pred>
     void pop_to_parent_node(uint32_t line, uint32_t indent, Pred&& pred) {
-        FK_YAML_ASSERT(!m_context_stack.empty());
+        // LCOV_EXCL_START
+        if FK_YAML_UNLIKELY (m_context_stack.empty()) {
+            throw parse_error("No parent block mapping is found.", line, indent);
+        }
+        // LCOV_EXCL_STOP
 
         // LCOV_EXCL_START
         auto itr = std::find_if(m_context_stack.rbegin(), m_context_stack.rend(), std::forward<Pred>(pred));
@@ -8402,40 +8932,10 @@ private:
     }
 
 private:
-    // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): many parser paths
-    // reach back()/pop_back() without first testing empty(). Malformed input can
-    // leave the stack empty at those points (e.g. a mapping key with no open
-    // context), which dereferences an empty deque instead of failing the parse.
-    // Funnelling every access through this wrapper turns those into parse_error.
-    struct context_stack_type : std::deque<parse_context> {
-        using base_type = std::deque<parse_context>;
-
-        parse_context& back() {
-            throw_if_empty();
-            return base_type::back();
-        }
-
-        const parse_context& back() const {
-            throw_if_empty();
-            return base_type::back();
-        }
-
-        void pop_back() {
-            throw_if_empty();
-            base_type::pop_back();
-        }
-
-        void throw_if_empty() const {
-            if FK_YAML_UNLIKELY (base_type::empty()) {
-                throw parse_error("Invalid document structure.", 0, 0);
-            }
-        }
-    };
-
     /// The currently focused YAML node.
     basic_node_type* mp_current_node {nullptr};
     /// The stack of parse contexts.
-    context_stack_type m_context_stack {};
+    std::deque<parse_context> m_context_stack {};
     /// The current depth of flow contexts.
     uint32_t m_flow_context_depth {0};
     /// The set of YAML directives.
@@ -8463,10 +8963,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/input/input_adapter.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_INPUT_INPUT_ADAPTER_HPP
@@ -8487,10 +8987,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/encodings/utf_encode_detector.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_DETECTOR_HPP
@@ -8504,10 +9004,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/encodings/utf_encode_t.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ENCODINGS_UTF_ENCODE_T_HPP
@@ -8627,27 +9127,40 @@ struct utf_encode_detector<ItrType, enable_if_t<is_iterator_of<ItrType, char>::v
         std::array<uint8_t, 4> bytes {{}};
         bytes.fill(0xFFu);
         auto current = begin;
+        int num_read = 0;
         for (int i = 0; i < 4 && current != end; i++, ++current) {
             bytes[i] = static_cast<uint8_t>(*current); // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+            ++num_read;
         }
 
         bool has_bom = false;
         const utf_encode_t encode_type = detect_encoding_type(bytes, has_bom);
 
         if (has_bom) {
-            // skip reading the BOM.
+            // Skip reading the BOM, but only when it is fully present in the input. The probe above pads
+            // unread positions with 0xFF, so an input shorter than the BOM (e.g. a lone 0xFE) can spuriously
+            // match a BOM pattern; advancing past the bytes actually read would move `begin` past `end`.
+            int bom_size = 0;
             switch (encode_type) {
             case utf_encode_t::UTF_8:
-                std::advance(begin, 3);
+                bom_size = 3;
                 break;
             case utf_encode_t::UTF_16BE:
             case utf_encode_t::UTF_16LE:
-                std::advance(begin, 2);
+                bom_size = 2;
                 break;
             case utf_encode_t::UTF_32BE:
             case utf_encode_t::UTF_32LE:
-                std::advance(begin, 4);
+                bom_size = 4;
                 break;
+            }
+            if (num_read >= bom_size) {
+                std::advance(begin, bom_size);
+            }
+            else {
+                // The match was against the padding, not a real BOM; treat the input as UTF-8 so the
+                // spurious encoding is not propagated.
+                return utf_encode_t::UTF_8;
             }
         }
 
@@ -8891,6 +9404,17 @@ FK_YAML_DETAIL_NAMESPACE_BEGIN
 template <typename IterType, typename = void>
 class iterator_input_adapter;
 
+template <typename IterType>
+uint8_t read_utf8_byte_or_throw(IterType& current, IterType end, std::initializer_list<uint8_t> bytes_read) {
+    if FK_YAML_UNLIKELY (current == end) {
+        throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", bytes_read);
+    }
+
+    const auto byte = static_cast<uint8_t>(*current);
+    ++current;
+    return byte;
+}
+
 /// @brief An input adapter for iterators of type char.
 /// @tparam IterType An iterator type.
 template <typename IterType>
@@ -8949,30 +9473,20 @@ private:
 
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
-
-        // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): the trailing
-        // bytes of a multibyte sequence were read as *++current with no test
-        // against m_end, so a sequence truncated by the end of the input read
-        // out of bounds. Reject it as bad encoding instead.
-        const auto next_byte = [&](uint8_t lead) {
-            if FK_YAML_UNLIKELY (++current == m_end) {
-                throw fkyaml::invalid_encoding("Truncated UTF-8 encoding.", {lead});
-            }
-            return static_cast<uint8_t>(*current);
-        };
-
         while (current != m_end) {
+            const IterType char_itr = current;
             const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(current);
+                    cr_itrs.emplace_back(char_itr);
                 }
                 break;
             case 2: {
-                const auto second = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -8980,8 +9494,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -8989,9 +9503,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
-                const auto fourth = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, m_end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9001,8 +9515,6 @@ private:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
-
-            ++current;
         }
 
         const bool is_contiguous_no_cr = cr_itrs.empty() && m_is_contiguous;
@@ -9021,7 +9533,7 @@ private:
         }
         m_buffer.append(current, m_end);
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -9050,15 +9562,15 @@ private:
         IterType current = m_begin;
         while (current != m_end || encoded_buf_size != 0) {
             while (current != m_end && encoded_buf_size < 2) {
-                const auto high = static_cast<uint8_t>(*current);
-                auto utf16 = static_cast<char16_t>(high << shift_bits[0]);
-                // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): the low
-                // byte was read as *++current without testing m_end, so an input
-                // whose length is not a multiple of 2 read past the end (and then
-                // incremented a past-the-end iterator).
-                if FK_YAML_UNLIKELY (++current == m_end) {
-                    throw fkyaml::invalid_encoding("Truncated UTF-16 encoding.", {high});
+                const auto first = static_cast<uint8_t>(*current);
+                ++current;
+                if FK_YAML_UNLIKELY (current == m_end) {
+                    throw invalid_encoding(
+                        "Invalid UTF-16 encoding detected.",
+                        std::array<char16_t, 2> {{static_cast<char16_t>(first), 0}});
                 }
+
+                auto utf16 = static_cast<char16_t>(first << shift_bits[0]);
                 utf16 |= static_cast<char16_t>(static_cast<uint8_t>(*current) << shift_bits[1]);
                 ++current;
 
@@ -9068,19 +9580,34 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -9110,20 +9637,19 @@ private:
 
         IterType current = m_begin;
         while (current != m_end) {
-            // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): four bytes
-            // were consumed with a single m_end test, so an input whose length is
-            // not a multiple of 4 read past the end. The chars were also shifted
-            // as signed char, which is UB for bytes >= 0x80.
-            uint32_t utf32_bits = 0;
-            for (int i = 0; i < 4; i++) {
+            uint8_t chars[4] {};
+            for (auto& c : chars) {
                 if FK_YAML_UNLIKELY (current == m_end) {
-                    throw fkyaml::invalid_encoding("Truncated UTF-32 encoding.", static_cast<char32_t>(utf32_bits));
+                    throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
                 }
-                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
-                utf32_bits |= static_cast<uint32_t>(static_cast<uint8_t>(*current)) << shift_bits[i];
+                c = static_cast<uint8_t>(*current);
                 ++current;
             }
-            const auto utf32 = static_cast<char32_t>(utf32_bits);
+
+            auto utf32 = static_cast<char32_t>(chars[0] << shift_bits[0]);
+            utf32 |= static_cast<char32_t>(chars[1] << shift_bits[1]);
+            utf32 |= static_cast<char32_t>(chars[2] << shift_bits[2]);
+            utf32 |= static_cast<char32_t>(chars[3] << shift_bits[3]);
 
             if FK_YAML_LIKELY (utf32 != char32_t(0x0000000Du)) {
                 utf8::from_utf32(utf32, utf8_buffer, utf8_buf_size);
@@ -9131,7 +9657,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9188,29 +9714,20 @@ public:
 
         IterType current = m_begin;
         std::deque<IterType> cr_itrs {};
-
-        // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): see the char
-        // adapter above — a multibyte sequence truncated by the end of the input
-        // read out of bounds.
-        const auto next_byte = [&](uint8_t lead) {
-            if FK_YAML_UNLIKELY (++current == m_end) {
-                throw fkyaml::invalid_encoding("Truncated UTF-8 encoding.", {lead});
-            }
-            return static_cast<uint8_t>(*current);
-        };
-
         while (current != m_end) {
+            const IterType char_itr = current;
             const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 if FK_YAML_UNLIKELY (first == 0x0D /*CR*/) {
-                    cr_itrs.emplace_back(current);
+                    cr_itrs.emplace_back(char_itr);
                 }
                 break;
             case 2: {
-                const auto second = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9218,8 +9735,8 @@ public:
                 break;
             }
             case 3: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9227,9 +9744,9 @@ public:
                 break;
             }
             case 4: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
-                const auto fourth = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, m_end, {first});
+                const auto third = read_utf8_byte_or_throw(current, m_end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, m_end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9239,8 +9756,6 @@ public:
             default:           // LCOV_EXCL_LINE
                 unreachable(); // LCOV_EXCL_LINE
             }
-
-            ++current;
         }
 
         m_buffer.reserve(std::distance(m_begin, m_end) - cr_itrs.size());
@@ -9252,7 +9767,7 @@ public:
         }
         std::transform(current, m_end, std::back_inserter(m_buffer), [](char8_t c) { return static_cast<char>(c); });
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9328,20 +9843,34 @@ public:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
                 encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9421,7 +9950,7 @@ public:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9511,26 +10040,16 @@ private:
 
         auto current = m_buffer.begin();
         auto end = m_buffer.end();
-
-        // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): see the char
-        // iterator adapter above — a multibyte sequence truncated by the end of
-        // the input read out of bounds.
-        const auto next_byte = [&](uint8_t lead) {
-            if FK_YAML_UNLIKELY (current == end) {
-                throw fkyaml::invalid_encoding("Truncated UTF-8 encoding.", {lead});
-            }
-            return static_cast<uint8_t>(*current++);
-        };
-
         while (current != end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 break;
             case 2: {
-                const auto second = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9538,8 +10057,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9547,9 +10066,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
-                const auto fourth = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9561,7 +10080,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -9584,7 +10103,15 @@ private:
         uint32_t utf8_buf_size {0};
 
         while (std::feof(m_file) == 0) {
-            while (encoded_buf_size < 2 && std::fread(&chars[0], sizeof(char), 2, m_file) == 2) {
+            while (encoded_buf_size < 2) {
+                const std::size_t size = std::fread(&chars[0], sizeof(char), 2, m_file);
+                if (size == 0) {
+                    break;
+                }
+                if FK_YAML_UNLIKELY (size != 2) {
+                    throw invalid_encoding("Invalid UTF-16 encoding detected.", std::array<char16_t, 2> {{0, 0}});
+                }
+
                 const auto utf16 = static_cast<char16_t>(
                     (static_cast<uint8_t>(chars[0]) << shift_bits[0]) |
                     (static_cast<uint8_t>(chars[1]) << shift_bits[1]));
@@ -9593,19 +10120,34 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -9631,8 +10173,11 @@ private:
 
         while (std::feof(m_file) == 0) {
             const std::size_t size = std::fread(&chars[0], sizeof(char), 4, m_file);
-            if (size != 4) {
+            if (size == 0) {
                 break;
+            }
+            if FK_YAML_UNLIKELY (size != 4) {
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -9645,7 +10190,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -9732,26 +10277,16 @@ private:
 
         auto current = m_buffer.begin();
         auto end = m_buffer.end();
-
-        // THRONE-PATCH (Throne#1746, upstream fktn-k/fkYAML#536): see the char
-        // iterator adapter above — a multibyte sequence truncated by the end of
-        // the input read out of bounds.
-        const auto next_byte = [&](uint8_t lead) {
-            if FK_YAML_UNLIKELY (current == end) {
-                throw fkyaml::invalid_encoding("Truncated UTF-8 encoding.", {lead});
-            }
-            return static_cast<uint8_t>(*current++);
-        };
-
         while (current != end) {
-            const auto first = static_cast<uint8_t>(*current++);
+            const auto first = static_cast<uint8_t>(*current);
+            ++current;
             const uint32_t num_bytes = utf8::get_num_bytes(first);
 
             switch (num_bytes) {
             case 1:
                 break;
             case 2: {
-                const auto second = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
                 const bool is_valid = utf8::validate(first, second);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second});
@@ -9759,8 +10294,8 @@ private:
                 break;
             }
             case 3: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
                 const bool is_valid = utf8::validate(first, second, third);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third});
@@ -9768,9 +10303,9 @@ private:
                 break;
             }
             case 4: {
-                const auto second = next_byte(first);
-                const auto third = next_byte(first);
-                const auto fourth = next_byte(first);
+                const auto second = read_utf8_byte_or_throw(current, end, {first});
+                const auto third = read_utf8_byte_or_throw(current, end, {first, second});
+                const auto fourth = read_utf8_byte_or_throw(current, end, {first, second, third});
                 const bool is_valid = utf8::validate(first, second, third, fourth);
                 if FK_YAML_UNLIKELY (!is_valid) {
                     throw fkyaml::invalid_encoding("Invalid UTF-8 encoding.", {first, second, third, fourth});
@@ -9782,7 +10317,7 @@ private:
             }
         }
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-16 encoded inputs.
@@ -9808,8 +10343,11 @@ private:
             while (encoded_buf_size < 2) {
                 m_istream->read(&chars[0], 2);
                 const std::streamsize size = m_istream->gcount();
-                if FK_YAML_UNLIKELY (size != 2) {
+                if (size == 0) {
                     break;
+                }
+                if FK_YAML_UNLIKELY (size != 2) {
+                    throw invalid_encoding("Invalid UTF-16 encoding detected.", std::array<char16_t, 2> {{0, 0}});
                 }
 
                 const auto utf16 = static_cast<char16_t>(
@@ -9821,19 +10359,34 @@ private:
                     encoded_buffer[encoded_buf_size++] = utf16;
                 }
             }
+            if (encoded_buf_size == 0) {
+                break;
+            }
 
             uint32_t consumed_size = 0;
             utf8::from_utf16(encoded_buffer, utf8_buffer, consumed_size, utf8_buf_size);
 
+            // Buffer management guarantees consumed_size <= encoded_buf_size.
+            // Keep this guard to prevent underflow if that invariant changes.
+            // LCOV_EXCL_START
+            if FK_YAML_UNLIKELY (consumed_size > encoded_buf_size) {
+                throw invalid_encoding("Invalid UTF-16 encoding detected.", encoded_buffer);
+            }
+            // LCOV_EXCL_STOP
+
             if FK_YAML_LIKELY (consumed_size == 1) {
                 encoded_buffer[0] = encoded_buffer[1];
+                encoded_buffer[1] = 0;
+            }
+            else {
+                encoded_buffer[0] = encoded_buffer[1] = 0;
             }
             encoded_buf_size -= consumed_size;
 
             m_buffer.append(reinterpret_cast<const char*>(utf8_buffer.data()), utf8_buf_size);
         } while (!m_istream->eof());
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
     /// @brief The concrete implementation of get_buffer_view() for UTF-32 encoded inputs.
@@ -9860,8 +10413,11 @@ private:
         do {
             m_istream->read(&chars[0], 4);
             const std::streamsize size = m_istream->gcount();
-            if FK_YAML_UNLIKELY (size != 4) {
+            if (size == 0) {
                 break;
+            }
+            if FK_YAML_UNLIKELY (size != 4) {
+                throw invalid_encoding("Invalid UTF-32 encoding detected.", static_cast<char32_t>(0));
             }
 
             const auto utf32 = static_cast<char32_t>(
@@ -9874,7 +10430,7 @@ private:
             }
         } while (!m_istream->eof());
 
-        return str_view {m_buffer.begin(), m_buffer.end()};
+        return m_buffer;
     }
 
 private:
@@ -10004,10 +10560,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/iterator.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_ITERATOR_HPP
@@ -10436,10 +10992,10 @@ struct tuple_element<I, ::fkyaml::detail::iterator<ValueType>> {
 // #include <fkYAML/detail/map_range_proxy.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_MAP_RANGE_PROXY_HPP
@@ -10640,10 +11196,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/node_ref_storage.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_NODE_REF_STORAGE_HPP
@@ -10671,17 +11227,32 @@ class node_ref_storage {
 
     using node_type = BasicNodeType;
 
+    template <typename... Args>
+    struct has_single_basic_node_arg : std::false_type {};
+
+    template <typename Arg>
+    struct has_single_basic_node_arg<Arg> : is_basic_node<Arg> {};
+
 public:
     /// @brief Construct a new node ref storage object with an rvalue basic_node object.
     /// @param n An rvalue basic_node object.
     explicit node_ref_storage(node_type&& n) noexcept(std::is_nothrow_move_constructible<node_type>::value)
-        : m_owned_value(std::move(n)) {
+        : m_owned_value(std::move(n)),
+          m_has_node_ref(true) {
     }
 
-    /// @brief Construct a new node ref storage object with an lvalue basic_node object.
-    /// @param n An lvalue basic_node object.
+    /// @brief Construct a new node ref storage object with a non-const lvalue basic_node object.
+    /// @param n A non-const lvalue basic_node object.
+    node_ref_storage(node_type& n) noexcept
+        : m_value_ref(&n),
+          m_has_node_ref(true) {
+    }
+
+    /// @brief Construct a new node ref storage object with a const lvalue basic_node object.
+    /// @param n A const lvalue basic_node object.
     explicit node_ref_storage(const node_type& n) noexcept
-        : m_value_ref(&n) {
+        : m_value_ref(&n),
+          m_has_node_ref(true) {
     }
 
     /// @brief Construct a new node ref storage object with a std::initializer_list object.
@@ -10695,7 +11266,8 @@ public:
     /// @param args Arguments to construct a basic_node object.
     template <typename... Args, enable_if_t<std::is_constructible<node_type, Args...>::value, int> = 0>
     node_ref_storage(Args&&... args)
-        : m_owned_value(std::forward<Args>(args)...) {
+        : m_owned_value(std::forward<Args>(args)...),
+          m_has_node_ref(has_single_basic_node_arg<Args...>::value) {
     }
 
     // allow only move construct/assignment
@@ -10719,11 +11291,17 @@ public:
         return m_value_ref ? *m_value_ref : std::move(m_owned_value);
     }
 
+    bool has_node_ref() const noexcept {
+        return m_has_node_ref;
+    }
+
 private:
     /// A storage for a basic_node object given with rvalue reference.
     mutable node_type m_owned_value = nullptr;
     /// A pointer to a basic_node object given with lvalue reference.
     const node_type* m_value_ref = nullptr;
+    /// Whether this object was constructed directly from a basic_node object.
+    bool m_has_node_ref = false;
 };
 
 FK_YAML_DETAIL_NAMESPACE_END
@@ -10733,10 +11311,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/output/serializer.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_OUTPUT_SERIALIZER_HPP
@@ -10752,10 +11330,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/conversions/to_string.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_CONVERSIONS_TO_STRING_HPP
@@ -11116,7 +11694,7 @@ private:
             const node_type type_if_plain =
                 scalar_scanner::scan(str_val.c_str(), str_val.c_str() + str_val.size()); // LCOV_EXCL_LINE
 
-            if (type_if_plain != node_type::STRING) {
+            if (type_if_plain != node_type::STRING || !is_valid_plain_scalar(str_val)) {
                 // Surround a string value with double quotes to keep semantic equality.
                 // Without them, serialized values will become non-string. (e.g., "1" -> 1)
                 str += '\"';
@@ -11213,6 +11791,39 @@ private:
         return yaml_escaper::escape(s.c_str(), s.c_str() + s.size(), is_escaped);
     } // LCOV_EXCL_LINE
 
+    bool is_valid_plain_scalar(const typename BasicNodeType::string_type& s) const noexcept {
+        if (s.empty()) {
+            return false;
+        }
+
+        typedef typename BasicNodeType::string_type string_type;
+        if (s.find_first_of(" \t\n\r,[]{}") != string_type::npos) {
+            return false;
+        }
+
+        switch (s.front()) {
+        case '-':
+        case '?':
+        case ':':
+            return s.size() > 1 && s[1] != ' ';
+        case '#':
+        case '&':
+        case '*':
+        case '!':
+        case '|':
+        case '>':
+        case '\'':
+        case '"':
+        case '%':
+        case '@':
+        case '`':
+        case ' ':
+            return false;
+        default:
+            return s.back() != ' ';
+        }
+    }
+
 private:
     /// A temporal buffer for conversion from a scalar to a string.
     std::string m_tmp_str_buff;
@@ -11225,10 +11836,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/reverse_iterator.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_REVERSE_ITERATOR_HPP
@@ -11485,10 +12096,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/types/yaml_version_t.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_TYPES_YAML_VERSION_T_HPP
@@ -11540,10 +12151,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/node_value_converter.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_NODE_VALUE_CONVERTER_HPP
@@ -11556,10 +12167,10 @@ FK_YAML_DETAIL_NAMESPACE_END
 // #include <fkYAML/detail/conversions/from_node.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_DETAIL_CONVERSIONS_FROM_NODE_HPP
@@ -11924,31 +12535,39 @@ struct from_node_int_helper {
     }
 };
 
-/// @brief Helper struct for node-to-int conversion if IntType is not the node's integer value type.
+/// @brief Partial specialization for uint64_t when integer_type != uint64_t (the common int64_t case).
+/// This must be declared BEFORE the generic <IntType, false> specialization so the compiler always
+/// prefers it for uint64_t. Using a hardcoded 'false' (not a value-dependent expression) avoids
+/// the MSVC ambiguity that arises when std::is_same<...>::value is used as a template argument.
 /// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam IntType Target integer value type (different from BasicNodeType::integer_type)
+template <typename BasicNodeType>
+struct from_node_int_helper<BasicNodeType, uint64_t, false> {
+    /// @brief Convert node's integer value to uint64_t via as_uint().
+    /// @param n A node object.
+    /// @return The node value as uint64_t.
+    static uint64_t convert(const BasicNodeType& n) {
+        return n.as_uint();
+    }
+};
+
+/// @brief Helper struct for node-to-int conversion if IntType is not the node's integer value type
+/// and IntType is not uint64_t (covered by the explicit specialization above).
+/// @tparam BasicNodeType A basic_node template instance type.
+/// @tparam IntType Target integer value type (different from BasicNodeType::integer_type, not uint64_t)
 template <typename BasicNodeType, typename IntType>
 struct from_node_int_helper<BasicNodeType, IntType, false> {
-    /// @brief Convert node's integer value to non-uint64_t integer types.
+    /// @brief Convert node's integer value to a narrower signed/unsigned integer type.
     /// @param n A node object.
     /// @return An integer value converted from the node's integer value.
     static IntType convert(const BasicNodeType& n) {
         using node_int_type = typename BasicNodeType::integer_type;
         const node_int_type tmp_int = n.as_int();
 
-        // under/overflow check.
-        if (std::is_same<IntType, uint64_t>::value) {
-            if FK_YAML_UNLIKELY (tmp_int < 0) {
-                throw exception("Integer value underflow detected.");
-            }
+        if FK_YAML_UNLIKELY (tmp_int < static_cast<node_int_type>(std::numeric_limits<IntType>::min())) {
+            throw exception("Integer value underflow detected.");
         }
-        else {
-            if FK_YAML_UNLIKELY (tmp_int < static_cast<node_int_type>(std::numeric_limits<IntType>::min())) {
-                throw exception("Integer value underflow detected.");
-            }
-            if FK_YAML_UNLIKELY (static_cast<node_int_type>(std::numeric_limits<IntType>::max()) < tmp_int) {
-                throw exception("Integer value overflow detected.");
-            }
+        if FK_YAML_UNLIKELY (static_cast<node_int_type>(std::numeric_limits<IntType>::max()) < tmp_int) {
+            throw exception("Integer value overflow detected.");
         }
 
         return static_cast<IntType>(tmp_int);
@@ -12235,326 +12854,6 @@ FK_YAML_NAMESPACE_END
 #endif /* FK_YAML_DETAIL_CONVERSIONS_FROM_NODE_HPP */
 
 // #include <fkYAML/detail/conversions/to_node.hpp>
-//  _______   __ __   __  _____   __  __  __
-// |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
-// |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
-//
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
-// SPDX-License-Identifier: MIT
-
-#ifndef FK_YAML_DETAIL_CONVERSIONS_TO_NODE_HPP
-#define FK_YAML_DETAIL_CONVERSIONS_TO_NODE_HPP
-
-#include <utility>
-
-// #include <fkYAML/detail/macros/define_macros.hpp>
-
-// #include <fkYAML/detail/exception_safe_allocation.hpp>
-
-// #include <fkYAML/detail/meta/node_traits.hpp>
-
-// #include <fkYAML/detail/meta/type_traits.hpp>
-
-// #include <fkYAML/detail/meta/stl_supplement.hpp>
-
-// #include <fkYAML/detail/node_attrs.hpp>
-
-// #include <fkYAML/node_type.hpp>
-
-
-FK_YAML_DETAIL_NAMESPACE_BEGIN
-
-///////////////////////////////////
-//   external_node_constructor   //
-///////////////////////////////////
-
-/// @brief The external constructor template for basic_node objects.
-/// @note All the non-specialized instantiations results in compilation error since such instantiations are not
-/// supported.
-/// @warning All the specialization must call n.m_value.destroy() first in the construct function to avoid
-/// memory leak.
-/// @tparam node_type The resulting YAML node value type.
-template <typename BasicNodeType>
-struct external_node_constructor {
-    template <typename... Args>
-    static void sequence(BasicNodeType& n, Args&&... args) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::seq_bit;
-        n.m_value.p_seq = create_object<typename BasicNodeType::sequence_type>(std::forward<Args>(args)...);
-    }
-
-    template <typename... Args>
-    static void mapping(BasicNodeType& n, Args&&... args) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::map_bit;
-        n.m_value.p_map = create_object<typename BasicNodeType::mapping_type>(std::forward<Args>(args)...);
-    }
-
-    static void null_scalar(BasicNodeType& n, std::nullptr_t) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::null_bit;
-        n.m_value.p_map = nullptr;
-    }
-
-    static void boolean_scalar(BasicNodeType& n, const typename BasicNodeType::boolean_type b) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::bool_bit;
-        n.m_value.boolean = b;
-    }
-
-    static void integer_scalar(BasicNodeType& n, const typename BasicNodeType::integer_type i) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::int_bit;
-        n.m_value.integer = i;
-    }
-
-    static void float_scalar(BasicNodeType& n, const typename BasicNodeType::float_number_type f) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::float_bit;
-        n.m_value.float_val = f;
-    }
-
-    template <typename... Args>
-    static void string_scalar(BasicNodeType& n, Args&&... args) {
-        destroy(n);
-        n.m_attrs |= node_attr_bits::string_bit;
-        n.m_value.p_str = create_object<typename BasicNodeType::string_type>(std::forward<Args>(args)...);
-    }
-
-private:
-    static void destroy(BasicNodeType& n) {
-        n.m_value.destroy(n.m_attrs & node_attr_mask::value);
-        n.m_attrs &= ~node_attr_mask::value;
-    }
-};
-
-/////////////////
-//   to_node   //
-/////////////////
-
-/// @brief to_node function for BasicNodeType::sequence_type objects.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T A sequence node value type.
-/// @param n A basic_node object.
-/// @param s A sequence node value object.
-template <
-    typename BasicNodeType, typename T,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>,
-            std::is_same<typename BasicNodeType::sequence_type, remove_cvref_t<T>>>::value,
-        int> = 0>
-inline void to_node(BasicNodeType& n, T&& s) noexcept {
-    external_node_constructor<BasicNodeType>::sequence(n, std::forward<T>(s));
-}
-
-/// @brief to_node function for compatible sequence types.
-/// @note This overload is enabled when
-/// * both begin()/end() functions are callable on a `CompatSeqType` object
-/// * CompatSeqType doesn't have `mapped_type` (mapping-like type)
-/// * BasicNodeType::string_type cannot be constructed from a CompatSeqType object (string-like type)
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam CompatSeqType A container type.
-/// @param n A basic_node object.
-/// @param s A container object.
-template <
-    typename BasicNodeType, typename CompatSeqType,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>,
-            negation<std::is_same<typename BasicNodeType::sequence_type, remove_cvref_t<CompatSeqType>>>,
-            negation<is_basic_node<CompatSeqType>>, detect::has_begin_end<CompatSeqType>,
-            negation<conjunction<detect::has_key_type<CompatSeqType>, detect::has_mapped_type<CompatSeqType>>>,
-            negation<std::is_constructible<typename BasicNodeType::string_type, CompatSeqType>>>::value,
-        int> = 0>
-// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward)
-inline void to_node(BasicNodeType& n, CompatSeqType&& s) {
-    using std::begin;
-    using std::end;
-    external_node_constructor<BasicNodeType>::sequence(n, begin(s), end(s));
-}
-
-/// @brief to_node function for std::pair objects.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T The first type of std::pair.
-/// @tparam U The second type of std::pair.
-/// @param n A basic_node object.
-/// @param p A std::pair object.
-template <typename BasicNodeType, typename T, typename U>
-inline void to_node(BasicNodeType& n, const std::pair<T, U>& p) {
-    n = {p.first, p.second};
-}
-
-/// @brief concrete implementation of to_node function for std::tuple objects.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam ...Types The value types of std::tuple.
-/// @tparam ...Idx Index sequence values for std::tuple value types.
-/// @param n A basic_node object.
-/// @param t A std::tuple object.
-/// @param _ An index sequence. (unused)
-template <typename BasicNodeType, typename... Types, std::size_t... Idx>
-inline void to_node_tuple_impl(BasicNodeType& n, const std::tuple<Types...>& t, index_sequence<Idx...> /*unused*/) {
-    n = {std::get<Idx>(t)...};
-}
-
-/// @brief to_node function for std::tuple objects with no value types.
-/// @note This implementation is needed since calling `to_node_tuple_impl()` with an empty tuple creates a null node.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @param n A basic_node object.
-/// @param _ A std::tuple object. (unused)
-template <typename BasicNodeType>
-inline void to_node(BasicNodeType& n, const std::tuple<>& /*unused*/) {
-    n = BasicNodeType::sequence();
-}
-
-/// @brief to_node function for std::tuple objects with at least one value type.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam ...FirstType The first value types of std::tuple.
-/// @tparam ...RestTypes The rest value types of std::tuple. (maybe empty)
-/// @param n A basic_node object.
-/// @param t A std::tuple object.
-template <typename BasicNodeType, typename FirstType, typename... RestTypes>
-inline void to_node(BasicNodeType& n, const std::tuple<FirstType, RestTypes...>& t) {
-    to_node_tuple_impl(n, t, index_sequence_for<FirstType, RestTypes...> {});
-}
-
-/// @brief to_node function for BasicNodeType::mapping_type objects.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T A mapping node value type.
-/// @param n A basic_node object.
-/// @param m A mapping node value object.
-template <
-    typename BasicNodeType, typename T,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>, std::is_same<typename BasicNodeType::mapping_type, remove_cvref_t<T>>>::value,
-        int> = 0>
-inline void to_node(BasicNodeType& n, T&& m) noexcept {
-    external_node_constructor<BasicNodeType>::mapping(n, std::forward<T>(m));
-}
-
-/// @brief to_node function for compatible mapping types.
-/// @note This overload is enabled when
-/// * both begin()/end() functions are callable on a `CompatMapType` object
-/// * CompatMapType has both `key_type` and `mapped_type`
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam CompatMapType A container type.
-/// @param n A basic_node object.
-/// @param m A container object.
-template <
-    typename BasicNodeType, typename CompatMapType,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>, negation<is_basic_node<CompatMapType>>,
-            negation<std::is_same<typename BasicNodeType::mapping_type, remove_cvref_t<CompatMapType>>>,
-            detect::has_begin_end<CompatMapType>, detect::has_key_type<CompatMapType>,
-            detect::has_mapped_type<CompatMapType>>::value,
-        int> = 0>
-inline void to_node(BasicNodeType& n, CompatMapType&& m) {
-    external_node_constructor<BasicNodeType>::mapping(n);
-    auto& map = n.as_map();
-    for (const auto& pair : std::forward<CompatMapType>(m)) {
-        map.emplace(pair.first, pair.second);
-    }
-}
-
-/// @brief to_node function for null objects.
-/// @tparam BasicNodeType A mapping node value type.
-/// @tparam NullType This must be std::nullptr_t type
-template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
-inline void to_node(BasicNodeType& n, std::nullptr_t /*unused*/) {
-    external_node_constructor<BasicNodeType>::null_scalar(n, nullptr);
-}
-
-/// @brief to_node function for BasicNodeType::boolean_type objects.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T A boolean scalar node value type.
-/// @param n A basic_node object.
-/// @param b A boolean scalar node value object.
-template <typename BasicNodeType, enable_if_t<is_basic_node<BasicNodeType>::value, int> = 0>
-inline void to_node(BasicNodeType& n, typename BasicNodeType::boolean_type b) noexcept {
-    external_node_constructor<BasicNodeType>::boolean_scalar(n, b);
-}
-
-/// @brief to_node function for integers.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T An integer type.
-/// @param n A basic_node object.
-/// @param i An integer object.
-template <
-    typename BasicNodeType, typename T,
-    enable_if_t<conjunction<is_basic_node<BasicNodeType>, is_non_bool_integral<T>>::value, int> = 0>
-inline void to_node(BasicNodeType& n, T i) noexcept {
-    external_node_constructor<BasicNodeType>::integer_scalar(n, i);
-}
-
-/// @brief to_node function for floating point numbers.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T A floating point number type.
-/// @param n A basic_node object.
-/// @param f A floating point number object.
-template <
-    typename BasicNodeType, typename T,
-    enable_if_t<conjunction<is_basic_node<BasicNodeType>, std::is_floating_point<T>>::value, int> = 0>
-inline void to_node(BasicNodeType& n, T f) noexcept {
-    external_node_constructor<BasicNodeType>::float_scalar(n, f);
-}
-
-/// @brief to_node function for compatible strings.
-/// @tparam BasicNodeType A basic_node template instance type.
-/// @tparam T A compatible string type.
-/// @param n A basic_node object.
-/// @param s A compatible string object.
-template <
-    typename BasicNodeType, typename T,
-    enable_if_t<
-        conjunction<
-            is_basic_node<BasicNodeType>, negation<is_null_pointer<T>>,
-            std::is_constructible<typename BasicNodeType::string_type, T>>::value,
-        int> = 0>
-inline void to_node(BasicNodeType& n, T&& s) {
-    external_node_constructor<BasicNodeType>::string_scalar(n, std::forward<T>(s));
-}
-
-/// @brief A function object to call to_node functions.
-/// @note User-defined specialization is available by providing implementation **OUTSIDE** fkyaml namespace.
-struct to_node_fn {
-    /// @brief Call to_node function suitable for the given T type.
-    /// @tparam BasicNodeType A basic_node template instance type.
-    /// @tparam T A target value type assigned to the basic_node object.
-    /// @param n A basic_node object.
-    /// @param val A target object assigned to the basic_node object.
-    /// @return decltype(to_node(n, std::forward<T>(val))) void by default. User can set it to some other type.
-    template <typename BasicNodeType, typename T>
-    auto operator()(BasicNodeType& n, T&& val) const
-        noexcept(noexcept(to_node(n, std::forward<T>(val)))) -> decltype(to_node(n, std::forward<T>(val))) {
-        return to_node(n, std::forward<T>(val));
-    }
-};
-
-FK_YAML_DETAIL_NAMESPACE_END
-
-FK_YAML_NAMESPACE_BEGIN
-
-#ifndef FK_YAML_HAS_CXX_17
-// anonymous namespace to hold `to_node` functor.
-// see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4381.html for why it's needed.
-namespace // NOLINT(cert-dcl59-cpp,fuchsia-header-anon-namespaces,google-build-namespaces)
-{
-#endif
-
-/// @brief A global object to represent ADL friendly to_node functor.
-// NOLINTNEXTLINE(misc-definitions-in-headers)
-FK_YAML_INLINE_VAR constexpr const auto& to_node = detail::static_const<detail::to_node_fn>::value;
-
-#ifndef FK_YAML_HAS_CXX_17
-} // namespace
-#endif
-
-FK_YAML_NAMESPACE_END
-
-#endif /* FK_YAML_DETAIL_CONVERSIONS_TO_NODE_HPP */
 
 
 FK_YAML_NAMESPACE_BEGIN
@@ -12598,10 +12897,10 @@ FK_YAML_NAMESPACE_END
 // #include <fkYAML/ordered_map.hpp>
 //  _______   __ __   __  _____   __  __  __
 // |   __| |_/  |  \_/  |/  _  \ /  \/  \|  |     fkYAML: A C++ header-only YAML library
-// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.2
+// |   __|  _  < \_   _/|  ___  |    _   |  |___  version 0.4.4
 // |__|  |_| \__|  |_|  |_|   |_|___||___|______| https://github.com/fktn-k/fkYAML
 //
-// SPDX-FileCopyrightText: 2023-2025 Kensuke Fukutani <fktn.dev@gmail.com>
+// SPDX-FileCopyrightText: 2023-2026 Kensuke Fukutani <fktn.dev@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #ifndef FK_YAML_ORDERED_MAP_HPP
@@ -13121,6 +13420,16 @@ public:
     /// @param[in] init A initializer list of basic_node objects.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/constructor/
     basic_node(initializer_list_t init) {
+        if (init.size() == 1 && init.begin()->has_node_ref()) {
+            const auto& node_ref = *init.begin();
+            bool is_bare_empty_collection =
+                !node_ref->is_scalar() && node_ref->empty() && !node_ref->is_anchor() && !node_ref->has_tag_name();
+            if (is_bare_empty_collection) {
+                basic_node(node_ref.release()).swap(*this);
+                return;
+            }
+        }
+
         bool is_mapping =
             std::all_of(init.begin(), init.end(), [](const detail::node_ref_storage<basic_node>& node_ref) {
                 // Do not use is_sequence_impl() since node_ref may be an anchor or alias.
@@ -13148,7 +13457,7 @@ public:
                 seq.emplace_back(std::move(elem_ref.release()));
             }
         }
-    }
+    } // LCOV_EXCL_LINE
 
     /// @brief Destroy the basic_node object and its value storage.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/destructor/
@@ -13459,7 +13768,7 @@ public:
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true if both types and values are equal, false otherwise.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_eq/
-    bool operator==(const basic_node& rhs) const noexcept {
+    bool operator==(const basic_node& rhs) const {
         const basic_node& lhs = resolve_reference();
         const basic_node& act_rhs = rhs.resolve_reference();
 
@@ -13513,7 +13822,7 @@ public:
     /// @param rhs A basic_node object to be compared with this basic_node object.
     /// @return true this basic_node object is less than `rhs`.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/operator_lt/
-    bool operator<(const basic_node& rhs) const noexcept {
+    bool operator<(const basic_node& rhs) const {
         if (operator==(rhs)) {
             return false;
         }
@@ -14019,13 +14328,61 @@ public:
     /// @brief Get the tag name associated with this basic_node object.
     /// @note Some tag name must be set before calling this method. Call has_tag_name() to see if this basic_node
     /// object has any tag name.
-    /// @return The tag name associated with the node. It may be empty.
+    /// @return The tag name associated with the node.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_tag_name/
     const std::string& get_tag_name() const {
         if FK_YAML_UNLIKELY (!has_tag_name()) {
             throw fkyaml::exception("No tag name has been set.");
         }
         return m_prop.tag;
+    }
+
+    /// @brief Get the resolved tag name associated with this basic_node object.
+    /// @note Some tag name must be set before calling this method. Call has_tag_name() to see if this basic_node object
+    /// has any tag name.
+    /// @return The resolved tag name associated with the node.
+    /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/get_resolved_tag_name/
+    std::string get_resolved_tag_name() const {
+        if FK_YAML_UNLIKELY (!has_tag_name()) {
+            throw fkyaml::exception("No tag name has been set.");
+        }
+
+        const auto& tag = m_prop.tag;
+
+        // non-specific tag
+        if (tag == "!") {
+            return tag;
+        }
+
+        // secondary tag handle
+        if (tag.rfind("!!", 0) == 0) {
+            if (mp_meta->secondary_handle_prefix.empty()) {
+                return "tag:yaml.org,2002:" + tag.substr(2);
+            }
+            return mp_meta->secondary_handle_prefix + tag.substr(2);
+        }
+
+        // named handles
+        for (const auto& named_handle_itr : mp_meta->named_handle_map) {
+            if (tag.rfind(named_handle_itr.first, 0) == 0) {
+                return named_handle_itr.second + tag.substr(named_handle_itr.first.size());
+            }
+        }
+
+        // vertabim tags
+        const bool is_verbatim = tag.rfind("!<", 0) == 0 && tag.back() == '>';
+        if (is_verbatim) {
+            // Verbatim tags (!<...>) are not subject to tag resolution.
+            // Anything in ... must not be expanded.
+            // https://yaml.org/spec/1.2.2/#691-node-tags
+            return tag.substr(2, tag.size() - 3);
+        }
+
+        // primary tag handle
+        if (mp_meta->primary_handle_prefix.empty()) {
+            return "!" + tag.substr(1);
+        }
+        return mp_meta->primary_handle_prefix + tag.substr(1);
     }
 
     /// @brief Add a tag name to this basic_node object.
@@ -14220,6 +14577,45 @@ public:
         throw fkyaml::type_error("The node value is not a boolean.", get_type());
     }
 
+    /// @brief Checks if the node value is an unsigned integer.
+    /// @return true if the node holds an unsigned integer, false otherwise.
+    bool is_uint() const noexcept {
+        const auto& resolved = resolve_reference();
+        if (resolved.is_uint_impl()) {
+            return true;
+        }
+        if (resolved.is_integer_impl() && resolved.m_value.integer >= static_cast<integer_type>(0)) {
+            // This is a signed integer node, but the value is non-negative,
+            // so it can be treated as an unsigned integer.
+            return true;
+        }
+        return false;
+    }
+
+    /// @brief Returns the integer node value as an unsigned 64-bit integer.
+    /// This is valid both for nodes where integer_type is unsigned and for nodes where a large
+    /// positive decimal scalar (> INT64_MAX) was stored with the uint_bit flag set.
+    /// @throw fkyaml::type_error if the node is not a compatible integer.
+    /// @return The node value as uint64_t.
+    uint64_t as_uint() const {
+        const basic_node& act_node = resolve_reference();
+        if FK_YAML_LIKELY (act_node.is_integer_impl()) {
+            // When integer_type is unsigned the stored value IS the uint64_t directly.
+            if (std::is_unsigned<integer_type>::value) {
+                return static_cast<uint64_t>(act_node.m_value.integer);
+            }
+            // When integer_type is signed, only uint_bit-marked nodes carry a uint64_t.
+            if (act_node.m_attrs & detail::node_attr_bits::uint_bit) {
+                return static_cast<uint64_t>(act_node.m_value.integer);
+            }
+            // Signed values in the non-negative range can be returned safely.
+            if (act_node.m_value.integer >= static_cast<integer_type>(0)) {
+                return static_cast<uint64_t>(act_node.m_value.integer);
+            }
+        }
+        throw fkyaml::type_error("The node value cannot be represented as an unsigned integer.", get_type());
+    }
+
     /// @brief Returns reference to the integer node value.
     /// @throw fkyaml::type_error The node value is not an integer.
     /// @return Reference to the integer node value.
@@ -14227,18 +14623,30 @@ public:
     integer_type& as_int() {
         basic_node& act_node = resolve_reference();
         if FK_YAML_LIKELY (act_node.is_integer_impl()) {
+            if FK_YAML_UNLIKELY (act_node.is_uint_impl()) {
+                throw fkyaml::type_error(
+                    "The integer value exceeds INT64_MAX and cannot be returned as a signed integer. "
+                    "Use as_uint() instead.",
+                    get_type());
+            }
             return act_node.m_value.integer;
         }
         throw fkyaml::type_error("The node value is not an integer.", get_type());
     }
 
     /// @brief Returns reference to the integer node value.
-    /// @throw fkyaml::type_error The node value is not an integer.
+    /// @throw fkyaml::type_error The node value is not an integer, or exceeds INT64_MAX.
     /// @return Constant reference to the integer node value.
     /// @sa https://fktn-k.github.io/fkYAML/api/basic_node/as_int/
     const integer_type& as_int() const {
         const basic_node& act_node = resolve_reference();
         if FK_YAML_LIKELY (act_node.is_integer_impl()) {
+            if FK_YAML_UNLIKELY (act_node.is_uint_impl()) {
+                throw fkyaml::type_error(
+                    "The integer value exceeds INT64_MAX and cannot be returned as a signed integer. "
+                    "Use as_uint() instead.",
+                    get_type());
+            }
             return act_node.m_value.integer;
         }
         throw fkyaml::type_error("The node value is not an integer.", get_type());
@@ -14473,14 +14881,47 @@ public:
         return {*this};
     }
 
+    /// @brief Erase a mapping entry by key.
+    /// @tparam KeyType A type for the input key (any type convertible to node).
+    /// @param key A key identifying the mapping entry to erase.
+    /// @return The number of erased entries (0 or 1).
+    template <typename KeyType>
+    size_type erase(KeyType&& key) {
+        basic_node key_node = std::forward<KeyType>(key);
+        basic_node& act_node = resolve_reference();
+        if FK_YAML_UNLIKELY (!act_node.is_mapping_impl()) {
+            throw type_error("erase() cannot be called on a non-mapping node.", get_type());
+        }
+
+        auto& map = *act_node.m_value.p_map;
+        for (auto itr = map.begin(); itr != map.end(); ++itr) {
+            bool key_found = itr->first == key_node;
+            if (key_found) {
+                map.erase(itr);
+                return size_type {1};
+            }
+        }
+        return size_type {0};
+    }
+
 private:
     /// @brief Resolves anchor/alias reference and returns reference to an actual value node.
     /// @return Reference to an actual value node.
     basic_node& resolve_reference() {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            return itr->second;
+            auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
+            std::advance(itr, offset);
+            auto& anchor = itr->second;
+
+            // Checks for cyclic references in the child nodes of the anchor node.
+            // If it does, throws an exception to prevent infinite recursion and stack overflow.
+            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            if FK_YAML_UNLIKELY (contains_self_ref) {
+                throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
+            }
+
+            return anchor;
         }
         return *this;
     }
@@ -14490,10 +14931,55 @@ private:
     const basic_node& resolve_reference() const {
         if FK_YAML_UNLIKELY (has_anchor_name()) {
             auto itr = mp_meta->anchor_table.equal_range(m_prop.anchor).first;
-            std::advance(itr, detail::node_attr_bits::get_anchor_offset(m_attrs));
-            return itr->second;
+            auto offset = detail::node_attr_bits::get_anchor_offset(m_attrs);
+            std::advance(itr, offset);
+            const auto& anchor = itr->second;
+
+            // Checks for cyclic references in the child nodes of the anchor node.
+            // If it does, throws an exception to prevent infinite recursion and stack overflow.
+            const bool contains_self_ref = anchor.contains_self_referential_alias(m_prop.anchor, offset);
+            if FK_YAML_UNLIKELY (contains_self_ref) {
+                throw fkyaml::exception("Cyclic reference detected during anchor/alias resolving.");
+            }
+
+            return anchor;
         }
         return *this;
+    }
+
+    /// @brief Checks if this node contains any alias node which references itself in its child nodes, which would cause
+    /// infinite recursion and then stack overflow.
+    ///
+    /// @param anchor_name The anchor name of the node to check.
+    /// @param anchor_offset The anchor offset of the node to check.
+    bool contains_self_referential_alias(const std::string& anchor_name, uint32_t anchor_offset) const {
+        std::vector<const basic_node*> stack {this};
+        while (!stack.empty()) {
+            const auto* node = stack.back();
+            stack.pop_back();
+            if (node->is_alias()) {
+                const auto& alias = *node;
+                const bool references_self =
+                    (alias.get_anchor_name() == anchor_name &&
+                     detail::node_attr_bits::get_anchor_offset(alias.m_attrs) == anchor_offset);
+                if (references_self) {
+                    return true;
+                }
+            }
+            else if (node->is_sequence()) {
+                for (const auto& child : node->as_seq()) {
+                    stack.push_back(&child);
+                }
+            }
+            else if (node->is_mapping()) {
+                for (const auto& entry : node->as_map()) {
+                    stack.push_back(&entry.first);
+                    stack.push_back(&entry.second);
+                }
+            }
+        }
+
+        return false;
     }
 
     bool is_sequence_impl() const noexcept {
@@ -14514,6 +15000,12 @@ private:
 
     bool is_integer_impl() const noexcept {
         return m_attrs & detail::node_attr_bits::int_bit;
+    }
+
+    bool is_uint_impl() const noexcept {
+        // Both int_bit and uint_bit must be set: this node stores a uint64_t value
+        // whose bit pattern was placed into the signed integer_type field.
+        return (m_attrs & detail::node_attr_bits::int_bit) && (m_attrs & detail::node_attr_bits::uint_bit);
     }
 
     bool is_float_number_impl() const noexcept {
@@ -14820,3 +15312,5 @@ private:
 };
 
 } // namespace std
+
+#endif /* FK_YAML_NODE_HPP */


### PR DESCRIPTION
### What

Replaces the vendored fkYAML single-header `3rdparty/fkYAML/node.hpp` (currently **v0.4.2**) with the official **v0.4.4** amalgamation.

### Why

`RawUpdater::updateClash` deserializes a subscription body with `fkyaml::node::deserialize(...)`, guarded only by `catch (const fkyaml::exception&)`. #1746 reported several deserializer memory-safety bugs reachable from a malicious subscription provider:

- out-of-bounds READ in the UTF-8 buffer view (~3-byte input)
- out-of-bounds READ in the UTF-16 buffer view (`01 00 0a`)
- invalid `m_context_stack.back()` on an empty deque in `deserialize_scalar` (SEGV)
- a UBSan misaligned/negative-shift site

These are not C++ exceptions, so `catch (fkyaml::exception&)` does not contain them — a crafted Clash YAML crashes the client on subscription update. fkYAML's author fixed the whole cluster in v0.4.4 and recommended replacing the header (comment in #1746).

### Verification

I built a driver that mirrors the `updateClash` path (`deserialize`, catching only `fkyaml::exception`) under ASan+UBSan and ran the reporters' minimal PoCs against both headers:

| input | v0.4.2 (bundled) | v0.4.4 |
|---|---|---|
| `01 00 0a` (UTF-16 tail) | stack-buffer-overflow READ | clean |
| 3-byte UTF-8 | heap-buffer-overflow READ | clean |
| empty-context-stack scalar | misaligned reference / SEGV | clean |
| full PoC corpus (incl. later refuzz set) | crashes | all clean |

fkYAML reports no backward-incompatible API changes since v0.4.2, so this is a drop-in replacement; the header also compiles standalone under `-std=c++20` (the project standard). CI will confirm the full build.

Fixes #1746