### PR TITLE
Fix #1790: discard test poll results from a finished sweep

### DIFF
--- a/include/ui/mainWindow/TestRunner.h
+++ b/include/ui/mainWindow/TestRunner.h
@@ -75,9 +75,10 @@ private:
 
     QString contextName(int entID) const;
 
-    void pollSpeedTest(const QMap<QString, int>& tag2entID, bool testCurrent);
+    // `gen` is the sweep the poll belongs to, re-checked once the query returns.
+    void pollSpeedTest(const QMap<QString, int>& tag2entID, bool testCurrent, quint64 gen);
 
-    void pollCountryTest(const QMap<QString, int>& tag2entID, bool testCurrent);
+    void pollCountryTest(const QMap<QString, int>& tag2entID, bool testCurrent, quint64 gen);
 
     void creditTraffic(const std::shared_ptr<Configs::Profile>& profile, const QString& tag,
                        qint64 curUp, qint64 curDown);

--- a/src/ui/mainWindow/TestRunner.cpp
+++ b/src/ui/mainWindow/TestRunner.cpp
@@ -301,6 +301,11 @@ void TestRunner::runLatencyGroup(LatencyKind kind, const QList<int>& requestedID
         mw_->UpdateDataView(true);
 
         auto runBatch = [this, isUrl](const QList<std::shared_ptr<Configs::Profile>>& profileSlice, const QList<int>& ids) {
+            // Per batch, not per probe: the probes of one batch run concurrently and
+            // drain each other's results from the core's global buffer, so they must
+            // share a generation. Outbound tags restart at every batch, so a poll left
+            // over from the previous one must not.
+            sessionGen_.fetch_add(1);
             auto buildObject = Configs::BuildTestConfig(profileSlice);
             if (!buildObject->error.isEmpty()) {
                 MW_show_log(MainWindow::tr("Failed to build test config for batch: ") + buildObject->error);
@@ -399,6 +404,8 @@ void TestRunner::runSpeedTests(const QList<int>& requestedIDs, bool testCurrent)
             mw_->dataViewHtmlGenerator_.seedSpeedTest(profileIDs.size());
             mw_->UpdateDataView(true);
             auto runBatch = [this](const QList<std::shared_ptr<Configs::Profile>>& profileSlice) {
+                // See runLatencyGroup: one generation per batch.
+                sessionGen_.fetch_add(1);
                 auto buildObject = Configs::BuildTestConfig(profileSlice);
                 if (!buildObject->error.isEmpty()) {
                     MW_show_log(MainWindow::tr("Failed to build batch test config: ") + buildObject->error);

--- a/src/ui/mainWindow/TestRunner.cpp
+++ b/src/ui/mainWindow/TestRunner.cpp
@@ -155,6 +155,10 @@ void TestRunner::runUrlProbe(const Target& target) {
             if (sessionGen_.load() != gen) return;
             bool ok = false;
             const auto resp = defaultClient->QueryURLTest(&ok);
+            // Re-checked: the tick's opening check is stale by now. A poll can sit in
+            // this RPC while its sweep ends and the next one zeroes the counter and
+            // reuses the positional outbound tags, so a late drain lands on the wrong run.
+            if (sessionGen_.load() != gen) return;
             if (!ok || resp.results.empty()) return;
 
             QList<int> updated;
@@ -217,6 +221,8 @@ void TestRunner::runIpProbe(const Target& target) {
             if (sessionGen_.load() != gen) return;
             bool ok = false;
             const auto resp = defaultClient->QueryIPTest(&ok);
+            // See runUrlProbe: the opening check cannot cover the query itself.
+            if (sessionGen_.load() != gen) return;
             if (!ok || resp.results.empty()) return;
 
             QList<int> updated;
@@ -462,10 +468,12 @@ void TestRunner::creditTraffic(const std::shared_ptr<Configs::Profile>& profile,
     Configs::dataManager->profilesRepo->SaveTraffic(profile);
 }
 
-void TestRunner::pollSpeedTest(const QMap<QString, int>& tag2entID, bool testCurrent)
+void TestRunner::pollSpeedTest(const QMap<QString, int>& tag2entID, bool testCurrent, quint64 gen)
 {
     bool ok = false;
     const auto res = defaultClient->QueryCurrentSpeedTests(&ok);
+    // See runUrlProbe: the opening check cannot cover the query itself.
+    if (sessionGen_.load() != gen) return;
     if (!ok || !res.is_running.value())
     {
         return;
@@ -496,10 +504,12 @@ void TestRunner::pollSpeedTest(const QMap<QString, int>& tag2entID, bool testCur
     });
 }
 
-void TestRunner::pollCountryTest(const QMap<QString, int>& tag2entID, bool testCurrent)
+void TestRunner::pollCountryTest(const QMap<QString, int>& tag2entID, bool testCurrent, quint64 gen)
 {
     bool ok = false;
     const auto res = defaultClient->QueryCountryTestResults(&ok);
+    // See runUrlProbe: the opening check cannot cover the query itself.
+    if (sessionGen_.load() != gen) return;
     if (!ok || res.results.empty())
     {
         return;
@@ -562,8 +572,8 @@ void TestRunner::runSpeedProbe(const Target& target)
     {
         ResultPoller poller([this, gen = sessionGen_.load(), tag2entID = target.tag2entID, testCurrent = target.testCurrent, speedtestConf] {
             if (sessionGen_.load() != gen) return;
-            if (speedtestConf == Configs::TestConfig::COUNTRY) pollCountryTest(tag2entID, testCurrent);
-            else pollSpeedTest(tag2entID, testCurrent);
+            if (speedtestConf == Configs::TestConfig::COUNTRY) pollCountryTest(tag2entID, testCurrent, gen);
+            else pollSpeedTest(tag2entID, testCurrent, gen);
         }, kSpeedPollIntervalMs);
 
         result = defaultClient->SpeedTest(&rpcOK, req, &coreError);


### PR DESCRIPTION
`~ResultPoller` doesn't join its tick, so a poll in a 30s RPC outlives the sweep that started it. It checks `sessionGen_` going in, not coming out, and credits what it drains to the sweep running now. That's the >100% bar: `seedLatencyTest()` has already zeroed `testProgress` and the late tick calls `addTestProgress()` anyway. Quieter half: chain tags are positional and the counter restarts each batch, so a stale `tag2entID` can write a latency onto the wrong profile.

Fix re-checks `sessionGen_` after each query returns, before crediting progress or touching a profile. Dropping a late drain loses nothing, the owning sweep's response carries the full result set.

The generation also bumps at the top of each batch, since the outbound tags restart there, so a poll left over from the previous batch is dropped as well. Probes inside one batch share it, they drain each other's results from the core's global buffer and are meant to.

Closes #1790
