### PR TITLE
Fix #1728: fill the active tab so it stands out from the inactive ones

### DIFF
--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -409,6 +409,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }</string>
        </property>
        <property name="currentIndex">
@@ -522,6 +524,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }</string>
              </property>
              <property name="tabPosition">

--- a/include/ui/mainwindow.ui
+++ b/include/ui/mainwindow.ui
@@ -401,6 +401,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
 
     border-radius: 4px;
     padding: 2px 4px;
@@ -409,8 +410,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }</string>
        </property>
        <property name="currentIndex">
@@ -516,6 +516,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
 
     border-radius: 4px;
     padding: 2px 4px;
@@ -524,8 +525,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }</string>
              </property>
              <property name="tabPosition">

--- a/include/ui/setting/RouteItem.ui
+++ b/include/ui/setting/RouteItem.ui
@@ -162,6 +162,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }
 
 QTabBar::tab:!selected {
@@ -479,6 +481,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/RouteItem.ui
+++ b/include/ui/setting/RouteItem.ui
@@ -154,6 +154,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -162,8 +163,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }
 
 QTabBar::tab:!selected {
@@ -473,6 +473,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -481,8 +482,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -46,6 +46,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -54,8 +55,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -54,6 +54,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_hotkey.ui
+++ b/include/ui/setting/dialog_hotkey.ui
@@ -38,6 +38,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_hotkey.ui
+++ b/include/ui/setting/dialog_hotkey.ui
@@ -30,6 +30,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -38,8 +39,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_manage_routes.ui
+++ b/include/ui/setting/dialog_manage_routes.ui
@@ -38,6 +38,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_manage_routes.ui
+++ b/include/ui/setting/dialog_manage_routes.ui
@@ -30,6 +30,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -38,8 +39,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_preset_settings.ui
+++ b/include/ui/setting/dialog_preset_settings.ui
@@ -38,6 +38,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/setting/dialog_preset_settings.ui
+++ b/include/ui/setting/dialog_preset_settings.ui
@@ -30,6 +30,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -38,8 +39,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }
 
 QTabBar::tab:!selected {

--- a/include/ui/stats/dialog_traffic_stats.ui
+++ b/include/ui/stats/dialog_traffic_stats.ui
@@ -118,6 +118,8 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
+    background: palette(highlight);
+    color: palette(highlighted-text);
 }</string>
      </property>
      <property name="currentIndex">

--- a/include/ui/stats/dialog_traffic_stats.ui
+++ b/include/ui/stats/dialog_traffic_stats.ui
@@ -110,6 +110,7 @@ QTabBar {
 
 QTabBar::tab {
     border: 1px solid #777777;
+    border-bottom: 3px solid transparent;
     border-radius: 4px;
 
     padding: 2px 4px;
@@ -118,8 +119,7 @@ QTabBar::tab {
 
 QTabBar::tab:selected {
     border: 1px solid palette(highlight);
-    background: palette(highlight);
-    color: palette(highlighted-text);
+    border-bottom: 3px solid palette(highlight);
 }</string>
      </property>
      <property name="currentIndex">


### PR DESCRIPTION
On the default System theme there's no application stylesheet, so `.ui` is all that styles the tabs, and the only thing separating the selected tab from the rest is a 1px border in the highlight color. On the reporter's Mint that accent is a faint blue, so the line all but disappears.

This keeps the edge approach rather than recoloring the tab, since `palette(highlight)` follows the OS accent on the System, Fusion and windows11 themes and a full fill would look wrong whenever the accent doesn't match the theme. The selected tab now gets a 3px bottom edge in that same color, and unselected tabs get a transparent one so every tab keeps the same height and nothing shifts when the selection moves. Applied to all nine tab bars, since the report isn't about one dialog.

Closes #1728
