### PR TITLE
Stop writing broken ftp/socks system proxy entries on Linux

### DIFF
--- a/3rdparty/qv2ray/v2/proxy/QvProxyConfigurator.cpp
+++ b/3rdparty/qv2ray/v2/proxy/QvProxyConfigurator.cpp
@@ -237,7 +237,7 @@ namespace Qv2ray::components::proxy {
     }
 #endif
 
-    void SetSystemProxy(int httpPort, int socksPort, QString scheme) {
+    void SetSystemProxy(int httpPort, int socksPort, QString scheme, bool setSocksSystemProxy) {
         const QString &address = "127.0.0.1";
         bool hasHTTP = (httpPort > 0 && httpPort < 65536);
         bool hasSOCKS = (socksPort > 0 && socksPort < 65536);
@@ -290,12 +290,18 @@ namespace Qv2ray::components::proxy {
         QString kwriteconfigCmd = qEnvironmentVariable("KDE_SESSION_VERSION") == "5" ? "kwriteconfig5" : qEnvironmentVariable("KDE_SESSION_VERSION") == "6" ? "kwriteconfig6" : "kwriteconfig";
 
         //
-        // Configure HTTP Proxies for HTTP, FTP and HTTPS
+        // Configure HTTP Proxies for HTTP, FTP and HTTPS.
+        //
+        // GNOME and KDE encode "use an HTTP proxy for FTP" differently. KDE's ftpProxy
+        // takes the http:// URL below and works fine, but GNOME's ftp schema means "a
+        // real FTP proxy lives here", which is never true of the mixed inbound, and the
+        // session exports it as ftp_proxy=ftp://... where curl and friends choke on it.
+        // So the ftp entry is written for KDE only.
         if (hasHTTP) {
             // iterate over protocols...
             for (const auto &protocol: QStringList{"http", "ftp", "https"}) {
                 // for GNOME:
-                {
+                if (protocol != "ftp") {
                     actions << ProcessArgument{"gsettings",
                                                {"set", "org.gnome.system.proxy." + protocol, "host", address}};
                     actions << ProcessArgument{"gsettings",
@@ -313,28 +319,44 @@ namespace Qv2ray::components::proxy {
             }
         }
 
-        // Configure SOCKS5 Proxies
-        if (hasSOCKS) {
-            // for GNOME:
-            {
-                actions << ProcessArgument{"gsettings", {"set", "org.gnome.system.proxy.socks", "host", address}};
-                actions << ProcessArgument{"gsettings",
-                                           {"set", "org.gnome.system.proxy.socks", "port", QSTRN(socksPort)}};
+        // Drop any ftp entry an older version wrote, so it stops generating ftp_proxy.
+        actions << ProcessArgument{"gsettings", {"reset", "org.gnome.system.proxy.ftp", "host"}};
+        actions << ProcessArgument{"gsettings", {"reset", "org.gnome.system.proxy.ftp", "port"}};
 
-                // for KDE:
-                if (isKDE) {
-                    actions << ProcessArgument{kwriteconfigCmd,
-                                               {"--file", configPath + "/kioslaverc", //
-                                                "--group", "Proxy Settings",          //
-                                                "--key", "socksProxy",                //
-                                                "socks://" + address + " " + QSTRN(socksPort)}};
-                }
-            }
+        // Configure SOCKS5 Proxies
+        //
+        // for GNOME: opt-in only. The entry itself is valid, but the session exports it
+        // as all_proxy=socks://..., a scheme several CLI tools reject. Non-HTTP traffic
+        // still reaches the tunnel without it, through use-same-proxy below. Anything
+        // else -- opted out, or no socks port -- means the entry should not be there.
+        if (hasSOCKS && setSocksSystemProxy) {
+            actions << ProcessArgument{"gsettings", {"set", "org.gnome.system.proxy.socks", "host", address}};
+            actions << ProcessArgument{"gsettings",
+                                       {"set", "org.gnome.system.proxy.socks", "port", QSTRN(socksPort)}};
+        } else {
+            actions << ProcessArgument{"gsettings", {"reset", "org.gnome.system.proxy.socks", "host"}};
+            actions << ProcessArgument{"gsettings", {"reset", "org.gnome.system.proxy.socks", "port"}};
         }
+
+        // for KDE: always. kioslaverc is read by KIO and never becomes an environment
+        // variable, so the problem above does not exist here.
+        if (hasSOCKS && isKDE) {
+            actions << ProcessArgument{kwriteconfigCmd,
+                                       {"--file", configPath + "/kioslaverc", //
+                                        "--group", "Proxy Settings",          //
+                                        "--key", "socksProxy",                //
+                                        "socks://" + address + " " + QSTRN(socksPort)}};
+        }
+
         // Setting Proxy Mode to Manual
         {
             // for GNOME:
             {
+                // use-same-proxy makes GLib fall back to the HTTP proxy for schemes with
+                // no entry of their own. Without it a user who turned it off gets
+                // direct:// for everything non-HTTP, leaking traffic past the tunnel.
+                actions << ProcessArgument{"gsettings",
+                                           {"set", "org.gnome.system.proxy", "use-same-proxy", "true"}};
                 actions << ProcessArgument{"gsettings", {"set", "org.gnome.system.proxy", "mode", "manual"}};
             }
 

--- a/3rdparty/qv2ray/v2/proxy/QvProxyConfigurator.hpp
+++ b/3rdparty/qv2ray/v2/proxy/QvProxyConfigurator.hpp
@@ -5,7 +5,7 @@
 //
 namespace Qv2ray::components::proxy {
     void ClearSystemProxy();
-    void SetSystemProxy(int http_port, int socks_port, QString scheme);
+    void SetSystemProxy(int http_port, int socks_port, QString scheme, bool setSocksSystemProxy = false);
 } // namespace Qv2ray::components::proxy
 
 using namespace Qv2ray::components;

--- a/include/database/SettingsRepo.h
+++ b/include/database/SettingsRepo.h
@@ -135,6 +135,10 @@ namespace Configs {
         bool net_use_proxy = false;
         bool net_insecure = false;
         bool reset_proxy_on_disable_sp = false;
+        // Linux/GNOME only: also write the socks system-proxy entry, which the session
+        // exports as all_proxy=socks://..., a scheme several CLI tools reject. Off by
+        // default; non-HTTP traffic is proxied either way.
+        bool set_socks_system_proxy = false;
 
         // Subscription
         QString user_agent = ""; // set at main.cpp

--- a/include/ui/setting/dialog_basic_settings.ui
+++ b/include/ui/setting/dialog_basic_settings.ui
@@ -1103,6 +1103,16 @@ QTabBar::tab:hover:!selected {
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="set_socks_system_proxy">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Also write the SOCKS system proxy entry, which makes the desktop export the &lt;span style=&quot; font-family:'monospace';&quot;&gt;all_proxy&lt;/span&gt; environment variable. Some terminal tools want it, but the &lt;span style=&quot; font-family:'monospace';&quot;&gt;socks://&lt;/span&gt; scheme it uses is rejected by others such as curl. Traffic is proxied either way, so leave this off unless you need the variable.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Set SOCKS system proxy entry</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="net_use_proxy">
             <property name="toolTip">

--- a/src/database/SettingsRepo.cpp
+++ b/src/database/SettingsRepo.cpp
@@ -74,6 +74,7 @@ namespace Configs {
             {"system_proxy_enabled",          &remember_system_proxy},
             {"tun_mode_enabled",              &remember_tun},
             {"reset_proxy_on_disable_sp", &reset_proxy_on_disable_sp},
+            {"set_socks_system_proxy",       &set_socks_system_proxy},
             {"dns_disable_cache", &dns_disable_cache},
             {"dns_disable_expire", &dns_disable_expire},
             {"dns_reverse_mapping", &dns_reverse_mapping},

--- a/src/ui/mainWindow/mainwindow_system.cpp
+++ b/src/ui/mainWindow/mainwindow_system.cpp
@@ -256,7 +256,8 @@ bool MainWindow::get_elevated_permissions(ExitReason reason) {
 void MainWindow::set_system_proxy(bool enable) {
     if (enable) {
         auto socks_port = Configs::dataManager->settingsRepo->inbound_socks_port;
-        SetSystemProxy(socks_port, socks_port, Configs::dataManager->settingsRepo->proxy_scheme);
+        SetSystemProxy(socks_port, socks_port, Configs::dataManager->settingsRepo->proxy_scheme,
+                       Configs::dataManager->settingsRepo->set_socks_system_proxy);
     } else {
         ClearSystemProxy();
     }

--- a/src/ui/setting/dialog_basic_settings.cpp
+++ b/src/ui/setting/dialog_basic_settings.cpp
@@ -55,6 +55,7 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     D_LOAD_STRING(test_latency_url)
     D_LOAD_BOOL(disable_tray)
     ui->reset_proxy_on_disable_sp->setChecked(Configs::dataManager->settingsRepo->reset_proxy_on_disable_sp);
+    D_LOAD_BOOL(set_socks_system_proxy)
     ui->url_timeout->setText(Int2String(Configs::dataManager->settingsRepo->url_test_timeout_ms));
     ui->speedtest_mode->setCurrentIndex(Configs::dataManager->settingsRepo->speed_test_mode);
     ui->test_timeout->setText(Int2String(Configs::dataManager->settingsRepo->speed_test_timeout_ms));
@@ -86,6 +87,11 @@ DialogBasicSettings::DialogBasicSettings(QWidget *parent)
     ui->proxy_scheme_l->hide();
     ui->proxy_scheme->hide();
     ui->windows_no_admin->hide();
+#endif
+
+#ifndef Q_OS_LINUX
+    // Only the Linux path writes per-protocol desktop proxy entries.
+    ui->set_socks_system_proxy->hide();
 #endif
 
     ui->max_log_line->setText(QString::number(Configs::dataManager->settingsRepo->max_log_line));
@@ -310,6 +316,7 @@ void DialogBasicSettings::accept() {
     Configs::dataManager->settingsRepo->allow_beta_update = ui->allow_beta->isChecked();
     Configs::dataManager->settingsRepo->disable_mixed_inbound = ui->disable_mixed_inbound->isChecked();
     Configs::dataManager->settingsRepo->reset_proxy_on_disable_sp = ui->reset_proxy_on_disable_sp->isChecked();
+    D_SAVE_BOOL(set_socks_system_proxy)
     D_SAVE_BOOL(inbound_auth)
     D_SAVE_STRING(inbound_user)
     D_SAVE_STRING(inbound_pass)


### PR DESCRIPTION
## Problem

On Linux, `SetSystemProxy` writes the proxy into the GNOME `ftp` and `socks`
schemas in addition to `http`/`https`. GNOME exports those into the session
environment as:

    ftp_proxy=ftp://127.0.0.1:2080
    all_proxy=socks://127.0.0.1:2080

Neither scheme is understood by curl and a number of other CLI tools — `socks://`
without a version suffix is not a proxy scheme curl accepts. The result is that
every program launched from the desktop session after enabling system proxy
inherits proxy variables it cannot use, and network calls fail in ways that look
unrelated to Throne.

The `ftp` entry is doubly wrong: it points an FTP-proxy client at the mixed
inbound, which does not speak the FTP proxy protocol at all.

## Fix

Only `http` and `https` are written now. The mixed inbound already serves SOCKS
and HTTP on the same port, so the separate SOCKS entry buys nothing: with
`org.gnome.system.proxy use-same-proxy` set, GLib falls back to the HTTP proxy
for every scheme, and non-HTTP traffic still goes through the tunnel via HTTP
`CONNECT` instead of SOCKS5.

Verified with `GProxyResolver`, which is what GTK/GNOME apps actually consult:

| URI | Before | After |
|---|---|---|
| `http://` | `http://127.0.0.1:2080` | `http://127.0.0.1:2080` |
| `https://` | `http://127.0.0.1:2080` | `http://127.0.0.1:2080` |
| `ftp://` | `ftp://127.0.0.1:2080` ❌ | `http://127.0.0.1:2080` |
| `tcp://…:22` | `socks5://127.0.0.1:2080` | `http://127.0.0.1:2080` |

Nothing falls through to a direct connection. Entries left behind by an earlier
version are reset, so existing installs stop emitting the bad variables after one
enable cycle rather than needing a manual `gsettings reset`.

## Opt-in setting

Some setups genuinely want `ftp_proxy` / `all_proxy` for terminal tooling, so the
old behaviour is available behind a new checkbox:

**Basic Settings → Miscellaneous → Network Settings → "Set SOCKS/FTP system proxy entries"**

- Defaults to off, so existing users get the fix with no migration — the DB loader
  falls back to the field initializer for the missing key.
- When on, `ftp` joins the http/https loop and the original SOCKS block runs
  verbatim, including the KDE `socksProxy` entry.
- When switched back off, the entries are reset rather than left stranded.
- Hidden on Windows and macOS, which do not use this code path (Windows uses the
  `proxy_scheme` combo, macOS sets SOCKS through `networksetup`).

## Testing

Tested on Ubuntu GNOME (`XDG_CURRENT_DESKTOP=ubuntu:GNOME`), Qt 6:

- Enabling system proxy writes only `http`/`https` and resets `ftp`/`socks`.
- `GProxyResolver` results match the table above.
- Toggling the new setting on restores the `ftp`/`socks` entries; toggling it off
  clears them again.
- After a reset, `systemctl --user show-environment` carries no proxy variables,
  so newly launched apps no longer inherit them. (Already-running processes keep
  their `environ` snapshot until restarted — expected, not something the app can
  change.)

The KDE branch is unchanged in structure but was not exercised — I have no KDE
session available.

## Known gap

When the setting is turned off, the GNOME `ftp`/`socks` keys are reset but KDE's
`socksProxy` key in `kioslaverc` is not cleared, so a KDE user who opts in and
back out keeps a stale entry. Adding `kwriteconfig --delete` there would fix it,
but I did not want to ship untested KDE behaviour in this PR. Happy to add it if
a KDE maintainer can verify.