### PR TITLE
re-add Url/Speed Test for selected group

### DIFF
--- a/src/ui/mainWindow/mainwindow_groups.cpp
+++ b/src/ui/mainWindow/mainwindow_groups.cpp
@@ -10,6 +10,7 @@
 #include "include/database/GroupsRepo.h"
 #include "include/ui/group/dialog_edit_group.h"
 #include "include/ui/mainWindow/MainWindowInternal.h"
+#include "include/ui/mainWindow/TestRunner.h"
 
 
 void MainWindow::on_tabWidget_currentChanged(int index) {
@@ -167,6 +168,14 @@ void MainWindow::on_tabWidget_customContextMenuRequested(const QPoint &p) {
             if (mw_sub_updating) return;
             mw_sub_updating = true;
             Subscription::groupUpdater->AsyncUpdate(group->url, group->id, [&] { mw_sub_updating = false; }, true);
+        });
+    }
+    if (clickedGroup != nullptr) {
+        connect(menu.addAction(tr("Url Test selected Group")), &QAction::triggered, this, [=,this]{
+            testRunner->runUrlTests(clickedGroup->Profiles());
+        });
+        connect(menu.addAction(tr("Speed Test selected Group")), &QAction::triggered, this, [=,this]{
+            testRunner->runSpeedTests(clickedGroup->Profiles());
         });
     }
     menu.exec(ui->tabWidget->tabBar()->mapToGlobal(p));


### PR DESCRIPTION
I added back the Url and Speed tests to the group context menu. this was present before, but got removed after the UI update.
It is much more convenient to use.

<img width="220" height="213" alt="image" src="https://github.com/user-attachments/assets/f81e858a-0b77-46dc-8fbc-7cd70f148deb" />

I tested the functionality on the windows build and it works. I used the existing function calls, so it should work everywhere else as well.