### PR TITLE
feat(xray): add FinalMask (fm) support

### DIFF
--- a/include/configs/common/xrayStreamSetting.h
+++ b/include/configs/common/xrayStreamSetting.h
@@ -147,6 +147,7 @@ namespace Configs {
         QString network = "raw";
         QString security = "none";
         QJsonObject rawSettings;
+        QJsonObject finalmask;
         std::shared_ptr<xrayTLS> TLS = std::make_shared<xrayTLS>();
         std::shared_ptr<xrayReality> reality = std::make_shared<xrayReality>();
         std::shared_ptr<xrayXHTTP> xhttp = std::make_shared<xrayXHTTP>();

--- a/include/ui/profile/dialog_edit_profile.h
+++ b/include/ui/profile/dialog_edit_profile.h
@@ -29,6 +29,7 @@ public slots:
 private slots:
     void on_certificate_edit_clicked();
     void on_xray_downloadsettings_edit_clicked();
+    void on_xray_finalmask_edit_clicked();
 private:
     Ui::DialogEditProfile *ui;
 
@@ -49,6 +50,7 @@ private:
     struct {
         QStringList certificate;
         QString XrayDownloadSettings;
+        QJsonObject XrayFinalmask;
     } CACHE;
 
     void typeSelected(const QString &newType);

--- a/include/ui/profile/dialog_edit_profile.ui
+++ b/include/ui/profile/dialog_edit_profile.ui
@@ -181,6 +181,20 @@
             <item row="1" column="1">
              <widget class="QComboBox" name="xray_security"/>
             </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_xray_finalmask">
+              <property name="text">
+               <string>Finalmask</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QPushButton" name="xray_finalmask_edit">
+              <property name="text">
+               <string>Not set</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>
@@ -1527,8 +1541,9 @@
   <tabstop>advanced_button</tabstop>
   <tabstop>fake</tabstop>
   <tabstop>xray_network</tabstop>
-  <tabstop>xray_security</tabstop>
-  <tabstop>xray_mux</tabstop>
+   <tabstop>xray_security</tabstop>
+   <tabstop>xray_finalmask_edit</tabstop>
+   <tabstop>xray_mux</tabstop>
   <tabstop>network</tabstop>
   <tabstop>security</tabstop>
   <tabstop>multiplex</tabstop>

--- a/src/configs/common/utils.cpp
+++ b/src/configs/common/utils.cpp
@@ -59,6 +59,8 @@ namespace Configs
         if (dataManager->settingsRepo->xray_vless_preference == Xray::AllVLESS
             || rawHttp
             || transport == "xhttp"
+            || query.hasQueryItem("fm")
+            || query.hasQueryItem("finalmask")
             || (query.queryItemValue("security") == "reality" && dataManager->settingsRepo->xray_vless_preference == Xray::XhttpAndReality)
             || (query.queryItemValue("encryption") != "none" && query.queryItemValue("encryption") != "")
             || query.queryItemValue("extra") != "") return true;

--- a/src/configs/common/xrayStreamSetting.cpp
+++ b/src/configs/common/xrayStreamSetting.cpp
@@ -1,6 +1,7 @@
 #include "include/configs/common/xrayStreamSetting.h"
 #include <QUrlQuery>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include "include/configs/common/utils.h"
 
 namespace Configs {
@@ -755,6 +756,18 @@ namespace Configs {
         if (!url.isValid()) return false;
         auto query = QUrlQuery(url.query());
 
+        if (query.hasQueryItem("fm") || query.hasQueryItem("finalmask")) {
+            auto key = query.hasQueryItem("fm") ? "fm" : "finalmask";
+            auto fmRaw = query.queryItemValue(key, QUrl::FullyDecoded);
+            QJsonParseError err;
+            auto doc = QJsonDocument::fromJson(fmRaw.toUtf8(), &err);
+            if (err.error == QJsonParseError::NoError && doc.isObject()) {
+                finalmask = doc.object();
+            } else if (err.error != QJsonParseError::NoError) {
+                MW_show_log("Failed to parse FinalMask JSON: " + err.errorString());
+            }
+        }
+
         if (query.hasQueryItem("type")) network = query.queryItemValue("type").replace("tcp", "raw");
         if (!Configs::XrayNetworks.contains(network)) return false;
         if (network == "raw" && query.queryItemValue("headerType") == "http") {
@@ -782,6 +795,8 @@ namespace Configs {
 
     bool xrayStreamSetting::ParseFromJson(const QJsonObject &object) {
         if (object.isEmpty()) return false;
+
+        if (object.contains("finalmask") && object["finalmask"].isObject()) finalmask = object["finalmask"].toObject();
 
         if (object.contains("method")) network = object.value("method").toString();
         else if (object.contains("network")) network = object.value("network").toString();
@@ -829,6 +844,7 @@ namespace Configs {
     QString xrayStreamSetting::ExportToLink() {
         QUrlQuery query;
         if (!network.isEmpty()) query.addQueryItem("type", network == "raw" ? "tcp" : network);
+        if (!finalmask.isEmpty()) query.addQueryItem("fm", QJsonObject2QString(finalmask, true));
         // value(), never operator[]: the mutable operator[] inserts a null entry for a missing key.
         if (const auto header = rawSettings.value("header").toObject();
             network == "raw" && header.value("type").toString() == "http") {
@@ -855,6 +871,7 @@ namespace Configs {
         QJsonObject object;
         object["network"] = network;
         object["security"] = security;
+        if (!finalmask.isEmpty()) object["finalmask"] = finalmask;
         if (network == "raw" && !rawSettings.isEmpty()) object["rawSettings"] = rawSettings;
         if (security == "tls") object["tlsSettings"] = TLS->ExportToJson();
         else if (security == "reality") object["realitySettings"] = reality->ExportToJson();

--- a/src/ui/profile/dialog_edit_profile.cpp
+++ b/src/ui/profile/dialog_edit_profile.cpp
@@ -631,6 +631,7 @@ void DialogEditProfile::typeSelected(const QString &newType) {
         ui->xray_max_reuse_times->setText(xrayStream->xhttp->cMaxReuseTimes);
         ui->xray_keep_alive_period->setText(Int2String(xrayStream->xhttp->hKeepAlivePeriod));
         CACHE.XrayDownloadSettings = xrayStream->xhttp->downloadSettings;
+        CACHE.XrayFinalmask = xrayStream->finalmask;
         ui->xray_downloadsettings_edit->setText(xrayStream->xhttp->downloadSettings.isEmpty() ? "Not Set" : "Already Set");
 
         ui->xray_network->setCurrentText(xrayStream->network);
@@ -823,6 +824,7 @@ bool DialogEditProfile::onEnd() {
 
         xrayStream->network = ui->xray_network->currentText().trimmed();
         xrayStream->security = ui->xray_security->currentText().trimmed();
+        xrayStream->finalmask = CACHE.XrayFinalmask;
         xrayMux->saveMuxState(ui->xray_mux->currentIndex());
 
         auto sni = ui->xray_sni->text().trimmed();
@@ -924,6 +926,7 @@ void DialogEditProfile::editor_cache_updated_impl() {
     }
     if (ent->outbound->IsXray()) {
         ui->xray_downloadsettings_edit->setText(CACHE.XrayDownloadSettings.isEmpty() ? "Not Set" : "Already Set");
+        ui->xray_finalmask_edit->setText(CACHE.XrayFinalmask.isEmpty() ? "Not Set" : "Already Set");
     }
     for (auto a: innerEditor->get_editor_cached()) {
         if (a.second.isEmpty()) {
@@ -948,6 +951,15 @@ void DialogEditProfile::on_xray_downloadsettings_edit_clicked() {
     auto result = editor->OpenEditor();
     if (!result.isEmpty()) CACHE.XrayDownloadSettings = QJsonObject2QString(result, true);
     else CACHE.XrayDownloadSettings.clear();
+    editor->deleteLater();
+
+    editor_cache_updated_impl();
+}
+
+void DialogEditProfile::on_xray_finalmask_edit_clicked() {
+    auto editor = new JsonEdit::JsonEditorDialog(CACHE.XrayFinalmask, this);
+    auto result = editor->OpenEditor();
+    CACHE.XrayFinalmask = result;
     editor->deleteLater();
 
     editor_cache_updated_impl();


### PR DESCRIPTION
### Description
Adds support for Xray's **FinalMask (`fm`)** parameter, allowing nodes with custom TCP/TLS fragmentation and packet masking rules to be imported, edited, and routed per profile.

### Changes
1. **Link Parsing & Export (`xrayStreamSetting`):**
   - Parse `fm` / `finalmask` query parameters from share URLs with error logging into `xrayStreamSetting::finalmask`.
   - Serialize `finalmask` into Xray outbound `streamSettings`.
2. **Routing Helper (`utils.cpp`):**
   - Update `useXrayVless()` to route VLESS links containing `fm` parameters to Xray-core.
3. **UI Integration (`dialog_edit_profile`):**
   - Add a Finalmask edit button to the Xray settings panel linked to the built-in `JsonEditorDialog`.

### Testing
- Tested importing and running `vless://` share links containing URL-encoded `fm` parameters.
- Verified Xray configuration generation, error logging, and profile UI editing.