### PR TITLE
fix bundled dashboard asset extraction path

### DIFF
--- a/src/ui/mainWindow/mainwindow_system.cpp
+++ b/src/ui/mainWindow/mainwindow_system.cpp
@@ -414,7 +414,7 @@ bool unpackBundledDashboard(const QDir &dest) {
     while (it.hasNext()) {
         const auto source = it.next();
         const auto target = dest.filePath(bundle.relativeFilePath(source));
-        if (!dest.mkpath(QFileInfo(target).path()) || !copyOut(source, target)) return false;
+        if (!QDir().mkpath(QFileInfo(target).absolutePath()) || !copyOut(source, target)) return false;
     }
     return true;
 }


### PR DESCRIPTION
## Summary

Fix bundled dashboard extraction when the destination directory is relative.

The target path already includes the dashboard directory, but it was passed back to dest.mkpath(), causing the destination prefix to be applied twice:

sb-dashboard/sb-dashboard/assets

As a result, the intended parent directory was not created and extraction stopped when copying nested assets.

This change creates the absolute parent directory of the target file, allowing all dashboard assets to be extracted into the correct location.

## Testing

Built the project through the workflow.

Manually ran and tested the resulting build artifact.

Confirmed that the dashboard assets are extracted under sb-dashboard/assets.

Confirmed that the dashboard opens and works normally.

Confirmed that the duplicate sb-dashboard/sb-dashboard directory is no longer created.