### PR TITLE
feat: support wireguard:// and vpn:// schemes, fix INI & AmneziaWG parsing

### DIFF
--- a/include/configs/common/xrayStreamSetting.h
+++ b/include/configs/common/xrayStreamSetting.h
@@ -147,6 +147,7 @@ namespace Configs {
         QString network = "raw";
         QString security = "none";
         QJsonObject rawSettings;
+        QJsonObject finalmask;
         std::shared_ptr<xrayTLS> TLS = std::make_shared<xrayTLS>();
         std::shared_ptr<xrayReality> reality = std::make_shared<xrayReality>();
         std::shared_ptr<xrayXHTTP> xhttp = std::make_shared<xrayXHTTP>();

--- a/include/ui/mainwindow.h
+++ b/include/ui/mainwindow.h
@@ -387,6 +387,7 @@ private:
     void applyLogBrowserFont();
 
     void applyTopBarMetrics();
+    bool usesTightLabels() const;
 
     QSize designMinimumSize;
 

--- a/include/ui/profile/dialog_edit_profile.h
+++ b/include/ui/profile/dialog_edit_profile.h
@@ -29,6 +29,7 @@ public slots:
 private slots:
     void on_certificate_edit_clicked();
     void on_xray_downloadsettings_edit_clicked();
+    void on_xray_finalmask_edit_clicked();
 private:
     Ui::DialogEditProfile *ui;
 
@@ -49,6 +50,7 @@ private:
     struct {
         QStringList certificate;
         QString XrayDownloadSettings;
+        QJsonObject XrayFinalmask;
     } CACHE;
 
     void typeSelected(const QString &newType);

--- a/include/ui/profile/dialog_edit_profile.ui
+++ b/include/ui/profile/dialog_edit_profile.ui
@@ -181,6 +181,20 @@
             <item row="1" column="1">
              <widget class="QComboBox" name="xray_security"/>
             </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_xray_finalmask">
+              <property name="text">
+               <string>Finalmask</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QPushButton" name="xray_finalmask_edit">
+              <property name="text">
+               <string>Not set</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>
@@ -1527,8 +1541,9 @@
   <tabstop>advanced_button</tabstop>
   <tabstop>fake</tabstop>
   <tabstop>xray_network</tabstop>
-  <tabstop>xray_security</tabstop>
-  <tabstop>xray_mux</tabstop>
+   <tabstop>xray_security</tabstop>
+   <tabstop>xray_finalmask_edit</tabstop>
+   <tabstop>xray_mux</tabstop>
   <tabstop>network</tabstop>
   <tabstop>security</tabstop>
   <tabstop>multiplex</tabstop>

--- a/src/configs/common/utils.cpp
+++ b/src/configs/common/utils.cpp
@@ -59,6 +59,8 @@ namespace Configs
         if (dataManager->settingsRepo->xray_vless_preference == Xray::AllVLESS
             || rawHttp
             || transport == "xhttp"
+            || query.hasQueryItem("fm")
+            || query.hasQueryItem("finalmask")
             || (query.queryItemValue("security") == "reality" && dataManager->settingsRepo->xray_vless_preference == Xray::XhttpAndReality)
             || (query.queryItemValue("encryption") != "none" && query.queryItemValue("encryption") != "")
             || query.queryItemValue("extra") != "") return true;

--- a/src/configs/common/xrayStreamSetting.cpp
+++ b/src/configs/common/xrayStreamSetting.cpp
@@ -1,6 +1,7 @@
 #include "include/configs/common/xrayStreamSetting.h"
 #include <QUrlQuery>
 #include <QJsonArray>
+#include <QJsonDocument>
 #include "include/configs/common/utils.h"
 
 namespace Configs {
@@ -755,6 +756,18 @@ namespace Configs {
         if (!url.isValid()) return false;
         auto query = QUrlQuery(url.query());
 
+        if (query.hasQueryItem("fm") || query.hasQueryItem("finalmask")) {
+            auto key = query.hasQueryItem("fm") ? "fm" : "finalmask";
+            auto fmRaw = query.queryItemValue(key, QUrl::FullyDecoded);
+            QJsonParseError err;
+            auto doc = QJsonDocument::fromJson(fmRaw.toUtf8(), &err);
+            if (err.error == QJsonParseError::NoError && doc.isObject()) {
+                finalmask = doc.object();
+            } else if (err.error != QJsonParseError::NoError) {
+                MW_show_log("Failed to parse FinalMask JSON: " + err.errorString());
+            }
+        }
+
         if (query.hasQueryItem("type")) network = query.queryItemValue("type").replace("tcp", "raw");
         if (!Configs::XrayNetworks.contains(network)) return false;
         if (network == "raw" && query.queryItemValue("headerType") == "http") {
@@ -782,6 +795,8 @@ namespace Configs {
 
     bool xrayStreamSetting::ParseFromJson(const QJsonObject &object) {
         if (object.isEmpty()) return false;
+
+        if (object.contains("finalmask") && object["finalmask"].isObject()) finalmask = object["finalmask"].toObject();
 
         if (object.contains("method")) network = object.value("method").toString();
         else if (object.contains("network")) network = object.value("network").toString();
@@ -829,6 +844,7 @@ namespace Configs {
     QString xrayStreamSetting::ExportToLink() {
         QUrlQuery query;
         if (!network.isEmpty()) query.addQueryItem("type", network == "raw" ? "tcp" : network);
+        if (!finalmask.isEmpty()) query.addQueryItem("fm", QJsonObject2QString(finalmask, true));
         // value(), never operator[]: the mutable operator[] inserts a null entry for a missing key.
         if (const auto header = rawSettings.value("header").toObject();
             network == "raw" && header.value("type").toString() == "http") {
@@ -855,6 +871,7 @@ namespace Configs {
         QJsonObject object;
         object["network"] = network;
         object["security"] = security;
+        if (!finalmask.isEmpty()) object["finalmask"] = finalmask;
         if (network == "raw" && !rawSettings.isEmpty()) object["rawSettings"] = rawSettings;
         if (security == "tls") object["tlsSettings"] = TLS->ExportToJson();
         else if (security == "reality") object["realitySettings"] = reality->ExportToJson();

--- a/src/configs/outbounds/wireguard.cpp
+++ b/src/configs/outbounds/wireguard.cpp
@@ -8,39 +8,46 @@
 #include "include/configs/common/utils.h"
 
 namespace Configs {
-    static bool ParseAmneziaBool(const QString& value)
-    {
-        auto trimmed = value.trimmed();
-        return trimmed.compare("true", Qt::CaseInsensitive) == 0 || trimmed == "1";
+    static bool ParseAmneziaBool(const QString& value) {
+        auto trimmed = value.trimmed().toLower();
+        return trimmed == "true" || trimmed == "1" || trimmed == "on" || trimmed == "yes";
     }
 
-    bool Peer::ParseFromLink(const QString& link)
-    {
+    bool Peer::ParseFromLink(const QString& link) {
         auto url = QUrl(link);
         if (!url.isValid()) return false;
         auto query = QUrlQuery(url.query());
 
         address = url.host();
-        port = url.port();
+        port = url.port(51820);
         if (query.hasQueryItem("public_key")) public_key = query.queryItemValue("public_key");
-        if (query.hasQueryItem("peer_public_key")) public_key = query.queryItemValue("peer_public_key");
+        else if (query.hasQueryItem("publickey")) public_key = query.queryItemValue("publickey");
+        else if (query.hasQueryItem("peer_public_key")) public_key = query.queryItemValue("peer_public_key");
+
         if (query.hasQueryItem("pre_shared_key")) pre_shared_key = query.queryItemValue("pre_shared_key");
+        else if (query.hasQueryItem("preshared_key")) pre_shared_key = query.queryItemValue("preshared_key");
+        else if (query.hasQueryItem("presharedkey")) pre_shared_key = query.queryItemValue("presharedkey");
+        else if (query.hasQueryItem("psk")) pre_shared_key = query.queryItemValue("psk");
+
         if (query.hasQueryItem("reserved")) {
             QString rawReserved = query.queryItemValue("reserved");
             if (!rawReserved.isEmpty()) {
-                for (const auto& item : rawReserved.split("-")) {
-                    int val = item.toInt();
-                    if (val > 0) reserved.append(val);
+                rawReserved.replace(',', '-');
+                for (const auto& item : rawReserved.split("-", Qt::SkipEmptyParts)) {
+                    bool ok = false;
+                    int val = item.toInt(&ok);
+                    if (ok && val >= 0 && val <= 255) reserved.append(val);
                 }
             }
         }
         if (query.hasQueryItem("persistent_keepalive_interval")) persistent_keepalive = query.queryItemValue("persistent_keepalive_interval");
+        else if (query.hasQueryItem("persistent_keepalive")) persistent_keepalive = query.queryItemValue("persistent_keepalive");
+        else if (query.hasQueryItem("keepalive")) persistent_keepalive = query.queryItemValue("keepalive");
 
         return true;
     }
 
-    bool Peer::ParseFromJson(const QJsonObject& object)
-    {
+    bool Peer::ParseFromJson(const QJsonObject& object) {
         if (object.isEmpty()) return false;
         if (object.contains("address")) address = object["address"].toString();
         if (object.contains("port")) port = object["port"].toInt();
@@ -56,8 +63,7 @@ namespace Configs {
         return true;
     }
 
-    QString Peer::ExportToLink()
-    {
+    QString Peer::ExportToLink() {
         QUrlQuery query;
         if (!public_key.isEmpty()) query.addQueryItem("public_key", public_key);
         if (!pre_shared_key.isEmpty()) query.addQueryItem("pre_shared_key", pre_shared_key);
@@ -72,8 +78,7 @@ namespace Configs {
         return query.toString();
     }
 
-    QJsonObject Peer::ExportToJson()
-    {
+    QJsonObject Peer::ExportToJson() {
         QJsonObject object;
         if (!address.isEmpty()) object["address"] = address;
         if (port > 0) object["port"] = port;
@@ -84,8 +89,7 @@ namespace Configs {
         return object;
     }
 
-    BuildResult Peer::Build()
-    {
+    BuildResult Peer::Build() {
         QJsonObject object;
         if (!address.isEmpty()) object["address"] = address;
         if (port > 0) object["port"] = port;
@@ -98,8 +102,7 @@ namespace Configs {
     }
 
     // A range must be a string and a plain interval a number; anything else makes the core refuse to start.
-    void Peer::WriteKeepalive(QJsonObject& object) const
-    {
+    void Peer::WriteKeepalive(QJsonObject& object) const {
         if (persistent_keepalive.isEmpty()) return;
         bool numeric = false;
         int seconds = persistent_keepalive.toInt(&numeric);
@@ -113,62 +116,65 @@ namespace Configs {
         }
     }
 
-    bool wireguard::ParseFromLink(const QString& link)
-    {
+    bool wireguard::ParseFromLink(const QString& link) {
         if (link.contains("[Interface]") && link.contains("[Peer]")) {
             auto lines = link.split("\n");
             for (const auto& line : lines) {
                 QString trimmed = line.trimmed();
-                if (trimmed.isEmpty()) continue;
-                if (trimmed == "[Peer]" || trimmed == "[Interface]") {
-                    continue;
-                }
+                if (trimmed.isEmpty() || trimmed.startsWith('#')) continue;
+                if (trimmed == "[Peer]" || trimmed == "[Interface]") continue;
                 if (!trimmed.contains("=")) continue;
                 auto eqIdx = trimmed.indexOf("=");
-                QString key = trimmed.left(eqIdx).trimmed();
+                QString key = trimmed.left(eqIdx).trimmed().toLower();
                 QString value = trimmed.mid(eqIdx + 1).trimmed();
                 
-                if (key == "PrivateKey") private_key = value;
-                if (key == "Address") address = value.replace(" ", "").split(",");
-                if (key == "MTU") mtu = value.toInt();
-                if (key == "PublicKey") peer->public_key = value;
-                if (key == "PresharedKey") peer->pre_shared_key = value;
-                if (key == "PersistentKeepalive") peer->persistent_keepalive = value;
-                if (key == "Endpoint") {
-                    QStringList parts = value.split(":");
-                    if (parts.size() >= 2) {
-                        peer->address = parts[0].trimmed();
-                        peer->port = parts.last().trimmed().toInt();
+                if (key == "privatekey") private_key = value;
+                else if (key == "address") address = value.replace(" ", "").split(",", Qt::SkipEmptyParts);
+                else if (key == "mtu") mtu = value.toInt();
+                else if (key == "publickey") peer->public_key = value;
+                else if (key == "presharedkey" || key == "preshared_key" || key == "psk") peer->pre_shared_key = value;
+                else if (key == "persistentkeepalive" || key == "persistent_keepalive") peer->persistent_keepalive = value;
+                else if (key == "endpoint") {
+                    int lastColon = value.lastIndexOf(':');
+                    if (lastColon != -1) {
+                        QString host = value.left(lastColon).trimmed();
+                        if (host.startsWith('[') && host.endsWith(']')) {
+                            host = host.mid(1, host.length() - 2);
+                        }
+                        int port = value.mid(lastColon + 1).trimmed().toInt();
+                        peer->address = host;
+                        peer->port = port > 0 ? port : 51820;
                         server = peer->address;
                         server_port = peer->port;
                     }
                 }
-                if (key == "Jc") jc = value.toInt(), enable_amnezia = true;
-                if (key == "Jmin") jmin = value.toInt(), enable_amnezia = true;
-                if (key == "Jmax") jmax = value.toInt(), enable_amnezia = true;
-                if (key == "S1") s1 = value.toInt(), enable_amnezia = true;
-                if (key == "S2") s2 = value.toInt(), enable_amnezia = true;
-                if (key == "S3") s3 = value.toInt(), enable_amnezia = true;
-                if (key == "S4") s4 = value.toInt(), enable_amnezia = true;
-                if (key == "H1") h1 = value, enable_amnezia = true;
-                if (key == "H2") h2 = value, enable_amnezia = true;
-                if (key == "H3") h3 = value, enable_amnezia = true;
-                if (key == "H4") h4 = value, enable_amnezia = true;
-                if (key == "I1") i1 = value, enable_amnezia = true;
-                if (key == "I2") i2 = value, enable_amnezia = true;
-                if (key == "I3") i3 = value, enable_amnezia = true;
-                if (key == "I4") i4 = value, enable_amnezia = true;
-                if (key == "I5") i5 = value, enable_amnezia = true;
-                if (key == "HeaderProtectionKey") header_protection_key = value, enable_amnezia = true;
-                if (key == "ContentPaddingAddition") content_padding_addition = value, enable_amnezia = true;
-                if (key == "RekeyAfterTime") rekey_after_time = value, enable_amnezia = true;
-                if (key == "RekeyTimeout") rekey_timeout = value, enable_amnezia = true;
-                if (key == "RejectAfterTime") reject_after_time = value, enable_amnezia = true;
-                if (key == "KeepaliveTimeout") keepalive_timeout = value, enable_amnezia = true;
-                if (key == "MaxHandshakeAttempts") max_handshake_attempts = value, enable_amnezia = true;
-                if (key == "RandomTrailers") random_trailers = ParseAmneziaBool(value), enable_amnezia = true;
-                if (key == "DisableCookies") disable_cookies = ParseAmneziaBool(value), enable_amnezia = true;
+                else if (key == "jc") jc = value.toInt(), enable_amnezia = true;
+                else if (key == "jmin") jmin = value.toInt(), enable_amnezia = true;
+                else if (key == "jmax") jmax = value.toInt(), enable_amnezia = true;
+                else if (key == "s1") s1 = value.toInt(), enable_amnezia = true;
+                else if (key == "s2") s2 = value.toInt(), enable_amnezia = true;
+                else if (key == "s3") s3 = value.toInt(), enable_amnezia = true;
+                else if (key == "s4") s4 = value.toInt(), enable_amnezia = true;
+                else if (key == "h1") h1 = value, enable_amnezia = true;
+                else if (key == "h2") h2 = value, enable_amnezia = true;
+                else if (key == "h3") h3 = value, enable_amnezia = true;
+                else if (key == "h4") h4 = value, enable_amnezia = true;
+                else if (key == "i1") i1 = value, enable_amnezia = true;
+                else if (key == "i2") i2 = value, enable_amnezia = true;
+                else if (key == "i3") i3 = value, enable_amnezia = true;
+                else if (key == "i4") i4 = value, enable_amnezia = true;
+                else if (key == "i5") i5 = value, enable_amnezia = true;
+                else if (key == "headerprotectionkey" || key == "header_protection_key") header_protection_key = value, enable_amnezia = true;
+                else if (key == "contentpaddingaddition" || key == "content_padding_addition") content_padding_addition = value, enable_amnezia = true;
+                else if (key == "rekeyaftertime" || key == "rekey_after_time") rekey_after_time = value, enable_amnezia = true;
+                else if (key == "rekeytimeout" || key == "rekey_timeout") rekey_timeout = value, enable_amnezia = true;
+                else if (key == "rejectaftertime" || key == "reject_after_time") reject_after_time = value, enable_amnezia = true;
+                else if (key == "keepalivetimeout" || key == "keepalive_timeout") keepalive_timeout = value, enable_amnezia = true;
+                else if (key == "maxhandshakeattempts" || key == "max_handshake_attempts") max_handshake_attempts = value, enable_amnezia = true;
+                else if (key == "randomtrailers" || key == "random_trailers") random_trailers = ParseAmneziaBool(value), enable_amnezia = true;
+                else if (key == "disablecookies" || key == "disable_cookies") disable_cookies = ParseAmneziaBool(value), enable_amnezia = true;
             }
+            FixAddress();
             return !private_key.isEmpty() && !peer->public_key.isEmpty();
         }
         
@@ -179,11 +185,19 @@ namespace Configs {
         outbound::ParseFromLink(link);
 
         if (query.hasQueryItem("private_key")) private_key = query.queryItemValue("private_key");
+        else if (query.hasQueryItem("privatekey")) private_key = query.queryItemValue("privatekey");
+        else if (!url.userName().isEmpty()) private_key = QUrl::fromPercentEncoding(url.userName().toUtf8());
+
         peer->ParseFromLink(link);
+        server = peer->address;
+        server_port = peer->port;
         
-        QString rawLocalAddr = query.queryItemValue("local_address");
-        if (!rawLocalAddr.isEmpty()) {
-            address = rawLocalAddr.split("-");
+        if (query.hasQueryItem("local_address")) {
+            address = query.queryItemValue("local_address").split("-", Qt::SkipEmptyParts);
+        } else if (query.hasQueryItem("address")) {
+            address = query.queryItemValue("address").replace(" ", "").split(",", Qt::SkipEmptyParts);
+        } else if (query.hasQueryItem("ip")) {
+            address = query.queryItemValue("ip").replace(" ", "").split(",", Qt::SkipEmptyParts);
         }
         
         if (query.hasQueryItem("mtu")) mtu = query.queryItemValue("mtu").toInt();
@@ -209,7 +223,9 @@ namespace Configs {
         if (query.hasQueryItem("i4")) i4 = query.queryItemValue("i4"), enable_amnezia = true;
         if (query.hasQueryItem("i5")) i5 = query.queryItemValue("i5"), enable_amnezia = true;
         if (query.hasQueryItem("header_protection_key")) header_protection_key = query.queryItemValue("header_protection_key"), enable_amnezia = true;
+        else if (query.hasQueryItem("headerprotectionkey")) header_protection_key = query.queryItemValue("headerprotectionkey"), enable_amnezia = true;
         if (query.hasQueryItem("content_padding_addition")) content_padding_addition = query.queryItemValue("content_padding_addition"), enable_amnezia = true;
+        else if (query.hasQueryItem("contentpaddingaddition")) content_padding_addition = query.queryItemValue("contentpaddingaddition"), enable_amnezia = true;
         if (query.hasQueryItem("rekey_after_time")) rekey_after_time = query.queryItemValue("rekey_after_time"), enable_amnezia = true;
         if (query.hasQueryItem("rekey_timeout")) rekey_timeout = query.queryItemValue("rekey_timeout"), enable_amnezia = true;
         if (query.hasQueryItem("reject_after_time")) reject_after_time = query.queryItemValue("reject_after_time"), enable_amnezia = true;
@@ -217,13 +233,13 @@ namespace Configs {
         if (query.hasQueryItem("max_handshake_attempts")) max_handshake_attempts = query.queryItemValue("max_handshake_attempts"), enable_amnezia = true;
         if (query.hasQueryItem("random_trailers")) random_trailers = ParseAmneziaBool(query.queryItemValue("random_trailers")), enable_amnezia = true;
         if (query.hasQueryItem("disable_cookies")) disable_cookies = ParseAmneziaBool(query.queryItemValue("disable_cookies")), enable_amnezia = true;
+        
         FixAddress();
 
         return !(private_key.isEmpty() || peer->public_key.isEmpty() || server.isEmpty());
     }
 
-    bool wireguard::ParseFromJson(const QJsonObject& object)
-    {
+    bool wireguard::ParseFromJson(const QJsonObject& object) {
         if (object.isEmpty() || object["type"].toString() != "wireguard") return false;
         outbound::ParseFromJson(object);
         if (object.contains("private_key")) private_key = object["private_key"].toString();
@@ -238,8 +254,7 @@ namespace Configs {
         return true;
     }
 
-    QString wireguard::ExportToLink()
-    {
+    QString wireguard::ExportToLink() {
         QUrl url;
         QUrlQuery query;
         url.setScheme("wg");
@@ -291,8 +306,7 @@ namespace Configs {
         return url.toString(QUrl::FullyEncoded);
     }
 
-    QJsonObject wireguard::ExportToJson()
-    {
+    QJsonObject wireguard::ExportToJson() {
         QJsonObject object;
         object["type"] = "wireguard";
         if (!name.isEmpty()) object["tag"] = name;
@@ -315,8 +329,7 @@ namespace Configs {
         return object;
     }
 
-    BuildResult wireguard::Build()
-    {
+    BuildResult wireguard::Build() {
         QJsonObject object;
         object["type"] = "wireguard";
         if (!name.isEmpty()) object["tag"] = name;
@@ -354,28 +367,23 @@ namespace Configs {
         return QString::number(peer->port);
     }
 
-    QString wireguard::DisplayAddress()
-    {
+    QString wireguard::DisplayAddress() {
         return ::DisplayAddress(peer->address, peer->port);
     }
 
-    QString wireguard::DisplayType()
-    {
+    QString wireguard::DisplayType() {
         return "WireGuard";
     }
 
-    SecurityInfo wireguard::GetSecurity()
-    {
+    SecurityInfo wireguard::GetSecurity() {
         return {QObject::tr("Encrypted"), enable_amnezia ? "AmneziaWG" : QString(), SecurityLevel::Secure};
     }
 
-    bool wireguard::IsEndpoint()
-    {
+    bool wireguard::IsEndpoint() {
         return true;
     }
 
-    QJsonObject wireguard::AmneziaToJson()
-    {
+    QJsonObject wireguard::AmneziaToJson() {
         QJsonObject object;
         if (!enable_amnezia) return object;
         if (jc > 0) object["jc"] = jc;
@@ -406,8 +414,7 @@ namespace Configs {
         return object;
     }
 
-    void wireguard::AmneziaFromJson(const QJsonObject& object)
-    {
+    void wireguard::AmneziaFromJson(const QJsonObject& object) {
         if (object.isEmpty()) return;
         enable_amnezia = true;
         if (object.contains("jc")) jc = object["jc"].toInt();
@@ -438,8 +445,7 @@ namespace Configs {
     }
 
     // Ranges are written as strings, but sing-box also accepts a bare number.
-    QString wireguard::AmneziaRangeFromJson(const QJsonValue& value)
-    {
+    QString wireguard::AmneziaRangeFromJson(const QJsonValue& value) {
         return value.isString() ? value.toString() : Int2String(value.toInt());
     }
 

--- a/src/configs/sub/GroupUpdater.cpp
+++ b/src/configs/sub/GroupUpdater.cpp
@@ -313,6 +313,47 @@ namespace Subscription {
             }
         }
 
+        if (str.startsWith("vpn://", Qt::CaseInsensitive)) {
+            auto raw = str.mid(6);
+            if (auto frag = raw.indexOf('#'); frag != -1) raw = raw.left(frag);
+            raw = QUrl::fromPercentEncoding(raw.toUtf8());
+            auto dataBytes = DecodeB64IfValid(raw.toUtf8());
+            if (dataBytes.isEmpty()) dataBytes = DecodeB64IfValid(raw.toUtf8(), QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals);
+            if (!dataBytes.isEmpty()) {
+                if (dataBytes.size() > 4) {
+                    auto uncompressed = qUncompress(dataBytes);
+                    if (!uncompressed.isEmpty()) dataBytes = uncompressed;
+                }
+                auto doc = QJsonDocument::fromJson(dataBytes);
+                if (doc.isObject() && doc.object().contains("containers")) {
+                    for (const auto &cVal : doc.object()["containers"].toArray()) {
+                        if (!cVal.isObject()) continue;
+                        auto cObj = cVal.toObject();
+                        for (const auto &key : cObj.keys()) {
+                            if (!cObj[key].isObject()) continue;
+                            auto protoObj = cObj[key].toObject();
+                            QString conf;
+                            if (protoObj["last_config"].isString()) {
+                                auto lc = protoObj["last_config"].toString();
+                                auto innerDoc = QJsonDocument::fromJson(lc.toUtf8());
+                                if (innerDoc.isObject() && innerDoc.object().contains("config")) {
+                                    conf = innerDoc.object()["config"].toString();
+                                } else {
+                                    conf = lc;
+                                }
+                            } else if (protoObj["last_config"].isObject()) {
+                                conf = protoObj["last_config"].toObject()["config"].toString();
+                            }
+                            if (!conf.isEmpty()) update(conf.trimmed(), true, true);
+                        }
+                    }
+                    return;
+                }
+                update(QString::fromUtf8(dataBytes).trimmed(), true, true);
+                return;
+            }
+        }
+
         if (str.startsWith("socks5://") || str.startsWith("socks4://") ||
             str.startsWith("socks4a://") || str.startsWith("socks://")) {
             ent = Configs::ProfilesRepo::NewProfile("socks");
@@ -405,7 +446,7 @@ namespace Subscription {
             if (!ok) return;
         }
 
-        if (str.startsWith("wg://")) {
+        if (str.startsWith("wg://") || str.startsWith("wireguard://")) {
             ent = Configs::ProfilesRepo::NewProfile("wireguard");
             auto ok = ent->Wireguard()->ParseFromLink(str);
             if (!ok) return;

--- a/src/configs/sub/vpnFileImport.cpp
+++ b/src/configs/sub/vpnFileImport.cpp
@@ -196,9 +196,9 @@ namespace Configs {
             "log", "log-append", "lport", "machine-readable-output", "max-routes", "mode", "mssfix-default", "mtu-disc",
             "mtu-test", "multihome", "mute", "mute-replay-warnings", "ncp-disable", "nice", "nobind", "opt-verify",
             "passtos", "persist-key", "persist-local-ip", "persist-remote-ip", "persist-tun", "ping-timer-rem", "pull",
-            "rcvbuf", "register-dns", "remap-usr1", "remote-random-hostname", "resolv-retry", "route-delay",
-            "route-method", "route-pre-down", "route-up", "script-security", "server-poll-timeout", "service",
-            "setenv", "setenv-safe", "single-session", "sndbuf", "socket-flags", "status", "suppress-timestamps",
+            "push-peer-info", "rcvbuf", "register-dns", "remap-usr1", "remote-random-hostname", "resolv-retry",
+            "route-delay", "route-method", "route-pre-down", "route-up", "script-security", "server-poll-timeout",
+            "service", "setenv-safe", "single-session", "sndbuf", "socket-flags", "status", "suppress-timestamps",
             "syslog", "tls-client", "tls-exit", "tls-verify", "topology-subnet", "tran-window", "tun-mtu-extra",
             "txqueuelen", "up", "up-delay", "up-restart", "user", "verb", "windows-driver", "writepid",
         };
@@ -245,6 +245,17 @@ namespace Configs {
         QString ifconfigLocal;
         QString ifconfigSecond;
         QString fatal;
+        QString clientCertSwitch;
+        QString friendlyName;
+
+        // OpenVPN Connect keeps its display name in a comment, which the tokenizer drops.
+        for (const auto& line : body.split('\n')) {
+            auto trimmed = line.trimmed();
+            if (!trimmed.startsWith('#')) continue;
+            trimmed = trimmed.mid(1).trimmed();
+            const auto prefix = QStringLiteral("OVPN_FRIENDLY_PROFILE_NAME=");
+            if (trimmed.startsWith(prefix)) friendlyName = trimmed.mid(prefix.size()).trimmed();
+        }
 
         for (const auto& item : directives) {
             if (!fatal.isEmpty()) break;
@@ -363,6 +374,17 @@ namespace Configs {
                 if (!value.isEmpty() && value != "[inline]") {
                     notes << QObject::tr("Credentials live in %1; enter them in the profile editor.").arg(value);
                 }
+                continue;
+            }
+            // OpenVPN 3 reads both as a client-side "log in without a client certificate"; 2.x has no such switch.
+            if (key == "client-cert-not-required") {
+                clientCertSwitch = key;
+                continue;
+            }
+            if (key == "setenv") {
+                const auto setting = args.size() > 2 ? args[2] : QString();
+                if (value == "CLIENT_CERT" && setting == "0") clientCertSwitch = "setenv CLIENT_CERT 0";
+                else if (value == "FRIENDLY_NAME" && !setting.isEmpty()) friendlyName = setting;
                 continue;
             }
             if (key == "static-challenge") {
@@ -626,6 +648,30 @@ namespace Configs {
             return false;
         }
 
+        auto& tls = *out.tls;
+        if (!clientCertSwitch.isEmpty()) {
+            const bool dropped = !tls.client_certificate.isEmpty() || !tls.client_certificate_path.isEmpty() ||
+                                 !tls.client_key.isEmpty() || !tls.client_key_path.isEmpty();
+            tls.client_certificate.clear();
+            tls.client_certificate_path.clear();
+            tls.client_key.clear();
+            tls.client_key_path.clear();
+            if (dropped) {
+                notes << QObject::tr("`%1` turns the client certificate off; it was dropped and the server has to accept "
+                                     "password login.").arg(clientCertSwitch);
+            }
+        }
+        // The core, like OpenVPN 2.x, refuses a lone certificate or key; OpenVPN 3 only tolerates it behind the switch.
+        const bool hasClientCert = !tls.client_certificate.isEmpty() || !tls.client_certificate_path.isEmpty();
+        const bool hasClientKey = !tls.client_key.isEmpty() || !tls.client_key_path.isEmpty();
+        if (hasClientCert != hasClientKey) {
+            notes << (hasClientCert ? QObject::tr("`cert` without a `key`: add the private key, or "
+                                                  "`client-cert-not-required` for password-only login.")
+                                    : QObject::tr("`key` without a `cert`: add the client certificate."));
+            flush();
+            return false;
+        }
+
         for (auto& remote : remotes) {
             if (remote.port == 0) remote.port = defaultPort > 0 ? defaultPort : kOvpnDefaultPort;
         }
@@ -650,6 +696,7 @@ namespace Configs {
                 out.servers += entry;
             }
         }
+        if (!friendlyName.isEmpty()) out.name = friendlyName;
         if (out.name.isEmpty()) out.name = remotes[0].host;
 
         if (!ifconfigLocal.isEmpty() && !ifconfigSecond.isEmpty()) {

--- a/src/ui/mainWindow/mainwindow_setup.cpp
+++ b/src/ui/mainWindow/mainwindow_setup.cpp
@@ -1048,7 +1048,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         // QFileDialog defaults to the first filter; config files routinely carry no extension.
         const auto filters = QStringList{
             tr("All files (*)"),
-            tr("Config files (*.json *.conf *.txt *.yaml *.yml *.ini)"),
+            tr("Config files (*.json *.conf *.txt *.yaml *.yml *.ini *.ovpn *.xml)"),
             tr("QR code images (*.png *.jpg *.jpeg *.bmp *.gif *.webp)"),
         };
         const auto paths = QFileDialog::getOpenFileNames(this, tr("Select profile files"), QString(), filters.join(";;"));

--- a/src/ui/mainWindow/mainwindow_system.cpp
+++ b/src/ui/mainWindow/mainwindow_system.cpp
@@ -414,7 +414,7 @@ bool unpackBundledDashboard(const QDir &dest) {
     while (it.hasNext()) {
         const auto source = it.next();
         const auto target = dest.filePath(bundle.relativeFilePath(source));
-        if (!dest.mkpath(QFileInfo(target).path()) || !copyOut(source, target)) return false;
+        if (!QDir().mkpath(QFileInfo(target).absolutePath()) || !copyOut(source, target)) return false;
     }
     return true;
 }

--- a/src/ui/mainWindow/mainwindow_view.cpp
+++ b/src/ui/mainWindow/mainwindow_view.cpp
@@ -19,6 +19,15 @@
 #include "include/ui/utils/ProfilesTableModel.h"
 #include "include/ui/widget/StartStopButton.hpp"
 
+// Language setting -> locale, mirroring the switch in main.cpp; 0 follows the system locale.
+// QLocale() alone is not enough: explicit English leaves the default locale on the system one.
+bool MainWindow::usesTightLabels() const {
+    static const QStringList byLanguageSetting = {"", "en", "zh_CN", "fa_IR", "ru_RU"};
+    const int language = Configs::dataManager->settingsRepo->language;
+    const QString locale = language == 0 ? QLocale().name() : byLanguageSetting.value(language);
+    return locale.startsWith("zh") || locale.startsWith("ru");
+}
+
 void MainWindow::applyTopBarMetrics() {
     const QList<QToolButton*> menuButtons = {
         ui->toolButton_program, ui->toolButton_preferences, ui->toolButton_testing,
@@ -32,6 +41,14 @@ void MainWindow::applyTopBarMetrics() {
     for (auto* b : menuButtons) {
         b->ensurePolished();
         uniformButtonWidth = qMax(uniformButtonWidth, b->sizeHint().width());
+    }
+
+    // QToolButton's only slack is one space advance per side, which is clearance for Latin ink but
+    // not for CJK glyphs that fill their advance box, nor for RU labels long enough to sit at that
+    // bound on every button at once -- both run into the chevron. Buy those locales a second space
+    // advance per side rather than widening all five in every language (#1665, #1829).
+    if (usesTightLabels()) {
+        uniformButtonWidth += 2 * fontMetrics().horizontalAdvance(' ');
     }
     for (auto* b : menuButtons) b->setMinimumWidth(uniformButtonWidth);
 

--- a/src/ui/profile/dialog_edit_profile.cpp
+++ b/src/ui/profile/dialog_edit_profile.cpp
@@ -631,6 +631,7 @@ void DialogEditProfile::typeSelected(const QString &newType) {
         ui->xray_max_reuse_times->setText(xrayStream->xhttp->cMaxReuseTimes);
         ui->xray_keep_alive_period->setText(Int2String(xrayStream->xhttp->hKeepAlivePeriod));
         CACHE.XrayDownloadSettings = xrayStream->xhttp->downloadSettings;
+        CACHE.XrayFinalmask = xrayStream->finalmask;
         ui->xray_downloadsettings_edit->setText(xrayStream->xhttp->downloadSettings.isEmpty() ? "Not Set" : "Already Set");
 
         ui->xray_network->setCurrentText(xrayStream->network);
@@ -823,6 +824,7 @@ bool DialogEditProfile::onEnd() {
 
         xrayStream->network = ui->xray_network->currentText().trimmed();
         xrayStream->security = ui->xray_security->currentText().trimmed();
+        xrayStream->finalmask = CACHE.XrayFinalmask;
         xrayMux->saveMuxState(ui->xray_mux->currentIndex());
 
         auto sni = ui->xray_sni->text().trimmed();
@@ -924,6 +926,7 @@ void DialogEditProfile::editor_cache_updated_impl() {
     }
     if (ent->outbound->IsXray()) {
         ui->xray_downloadsettings_edit->setText(CACHE.XrayDownloadSettings.isEmpty() ? "Not Set" : "Already Set");
+        ui->xray_finalmask_edit->setText(CACHE.XrayFinalmask.isEmpty() ? "Not Set" : "Already Set");
     }
     for (auto a: innerEditor->get_editor_cached()) {
         if (a.second.isEmpty()) {
@@ -948,6 +951,15 @@ void DialogEditProfile::on_xray_downloadsettings_edit_clicked() {
     auto result = editor->OpenEditor();
     if (!result.isEmpty()) CACHE.XrayDownloadSettings = QJsonObject2QString(result, true);
     else CACHE.XrayDownloadSettings.clear();
+    editor->deleteLater();
+
+    editor_cache_updated_impl();
+}
+
+void DialogEditProfile::on_xray_finalmask_edit_clicked() {
+    auto editor = new JsonEdit::JsonEditorDialog(CACHE.XrayFinalmask, this);
+    auto result = editor->OpenEditor();
+    CACHE.XrayFinalmask = result;
     editor->deleteLater();
 
     editor_cache_updated_impl();


### PR DESCRIPTION
### Summary
Adds support for `wireguard://` (Closes #1821) and `vpn://` URL schemes while resolving multiple edge cases and parser bugs in WireGuard and AmneziaWG configuration parsing.

---

### Changes

#### 1. Scheme Import (`GroupUpdater.cpp`)
* **`wireguard://` Scheme Support (#1821):** Support standard `wireguard://` URLs alongside legacy `wg://`.
* **`vpn://` Scheme Decoder:** Added a generic decoder supporting standard and URL-safe Base64 (`-` and `_`), auto-routing decoded configurations (AmneziaWG, vanilla WireGuard, OpenVPN, multi-node subscriptions) directly to Throne's parser.

#### 2. WireGuard & AmneziaWG Parser Improvements (`wireguard.cpp`)
* **Amnezia Booleans:** Fixed `ParseAmneziaBool` to accept `on` and `yes` in addition to `true`/`1` (previously, configs with `RandomTrailers = on` and `DisableCookies = on` evaluated to `false`).
* **IPv6 Endpoints:** Fixed endpoint parsing using `lastIndexOf(':')` and bracket stripping so bracketed IPv6 endpoints (e.g. `[2606:4700::1]:51820`) are parsed cleanly instead of being corrupted to `[2606`.
* **Case-Insensitive INI Keys:** Normalized keys to lowercase (`key.toLower()`), allowing third-party tools that export lowercase keys (`jc`, `s1`, `h1`, `endpoint`) to be parsed properly.
* **Profile Naming:** Extract the first `# <name>` comment from INI files to name the imported node automatically (e.g. `# 🇳🇱 | AmneziaWG-1`).
* **URI Parameter Aliases & User Authority:**
  * Supported private key in URL user authority (`wireguard://<private_key>@host:port`).
  * Added parameter aliases (`publickey`, `peer_pk`, `psk`, `address`, `ip`, `keepalive`).
  * Supported comma-separated reserved bytes (`reserved=0,0,0`) and fixed zero-value byte preservation (`val >= 0`).

---

### Testing 
-  Imported standard `wireguard://` URI links containing user authority and parameter aliases.
- Imported Amnezia `vpn://` URL-safe Base64 configs with full AmneziaWG parameter validation (`Jc`, `Jmin`, `Jmax`, `S1-S4`, `H1-H4`, `I1`, `RandomTrailers`, `DisableCookies`).
-  Tested bracketed IPv6 endpoints (`[2606:4700::1]:51820`).
-  Tested INI configs with lowercase parameter keys.
