### PR TITLE
Name the hotkey Global tab fields for screen readers

### DIFF
--- a/include/ui/setting/dialog_hotkey.ui
+++ b/include/ui/setting/dialog_hotkey.ui
@@ -29,6 +29,9 @@
          <property name="text">
           <string>Trigger main window</string>
          </property>
+         <property name="buddy">
+          <cstring>show_mainwindow</cstring>
+         </property>
         </widget>
        </item>
        <item row="0" column="1">
@@ -38,6 +41,9 @@
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Show groups</string>
+         </property>
+         <property name="buddy">
+          <cstring>show_groups</cstring>
          </property>
         </widget>
        </item>
@@ -49,6 +55,9 @@
          <property name="text">
           <string>Show routes</string>
          </property>
+         <property name="buddy">
+          <cstring>show_routes</cstring>
+         </property>
         </widget>
        </item>
        <item row="2" column="1">
@@ -59,6 +68,9 @@
          <property name="text">
           <string>Proxy mode</string>
          </property>
+         <property name="buddy">
+          <cstring>system_proxy</cstring>
+         </property>
         </widget>
        </item>
        <item row="3" column="1">
@@ -68,6 +80,9 @@
         <widget class="QLabel" name="toggle_proxy_l">
          <property name="text">
           <string>Toggle System Proxy</string>
+         </property>
+         <property name="buddy">
+          <cstring>toggle_proxy</cstring>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Screen readers take a widget's accessible name from the QLabel whose buddy it is. The Shortcuts tab gets that from QFormLayout::addRow, but the Global tab comes from dialog_hotkey.ui with plain labels next to the fields, so NVDA and JAWS land on each key sequence editor without a name.

Each Global tab label now has its field as buddy, the same mechanism the Shortcuts tab already relies on, and no strings change. Verified with uic and a full build; the generated code calls setBuddy for the five rows. I don't have NVDA or JAWS set up here, so it would help if the reporter could confirm.

Closes #1708
