### PR TITLE
Keep profile editor buttons reachable on small screens

### DIFF
--- a/include/ui/profile/dialog_edit_profile.h
+++ b/include/ui/profile/dialog_edit_profile.h
@@ -65,6 +65,8 @@ private:
 
     void queueRefreshDialogLayout();
 
+    void fitToScreen();
+
     bool validateHeaders();
 
     bool validateXrayXHTTPSettings();

--- a/include/ui/profile/dialog_edit_profile.ui
+++ b/include/ui/profile/dialog_edit_profile.ui
@@ -123,7 +123,18 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
          <item>
-          <widget class="QWidget" name="fake" native="true"/>
+          <widget class="ContentSizedScrollArea" name="bean_scroll">
+           <property name="focusPolicy">
+            <enum>Qt::FocusPolicy::NoFocus</enum>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="fake" native="true"/>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -1513,6 +1524,11 @@
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>ContentSizedScrollArea</class>
+   <extends>QScrollArea</extends>
+   <header>include/ui/utils/ContentSizedScrollArea.h</header>
+  </customwidget>
   <customwidget>
    <class>MyLineEdit</class>
    <extends>QLineEdit</extends>

--- a/include/ui/utils/ContentSizedScrollArea.h
+++ b/include/ui/utils/ContentSizedScrollArea.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QScrollArea>
+
+// QScrollArea::sizeHint() caps at QSize(36 * h, 24 * h) font heights even with AdjustToContents (that policy
+// only reaches QAbstractScrollArea::sizeHint(), which QScrollArea overrides), so the other scroll areas in the
+// profile dialog only look right because their content stays small. Report the content's own hint instead;
+// the small minimumSizeHint still lets the window shrink below it and scroll.
+class ContentSizedScrollArea : public QScrollArea {
+public:
+    explicit ContentSizedScrollArea(QWidget *parent = nullptr) : QScrollArea(parent) {
+    }
+
+    QSize sizeHint() const override {
+        if (widget() == nullptr) return QScrollArea::sizeHint();
+        const int frame = 2 * frameWidth();
+        return widget()->sizeHint() + QSize(frame, frame);
+    }
+};

--- a/src/ui/profile/dialog_edit_profile.cpp
+++ b/src/ui/profile/dialog_edit_profile.cpp
@@ -23,6 +23,7 @@
 
 #include <QInputDialog>
 #include <QLabel>
+#include <QScreen>
 #include <QSet>
 
 #include "include/configs/common/TLS.h"
@@ -95,10 +96,19 @@ void rebuildTabOrder(const QList<QWidget *> &tabOrder) {
 }
 
 void DialogEditProfile::queueRefreshDialogLayout() {
-    runOnThread([=,this] {
-        adjustSize();
-        adjustPosition(mainwindow);
-    }, this);
+    runOnThread([=,this] { fitToScreen(); }, this);
+}
+
+void DialogEditProfile::fitToScreen() {
+    // adjustSize() clamps to 2/3 of the screen; size to the content and let the editor scroll only once the work area is smaller.
+    layout()->activate();
+    QSize want = sizeHint();
+    if (const QScreen *scr = parentWidget() ? parentWidget()->screen() : screen()) {
+        const QRect avail = scr->availableGeometry();
+        want = want.boundedTo(QSize(avail.width() - 24, avail.height() - 72));
+    }
+    resize(want);
+    adjustPosition(mainwindow);
 }
 
 void DialogEditProfile::toggleSingboxWidgets(bool show) {
@@ -661,12 +671,12 @@ void DialogEditProfile::typeSelected(const QString &newType) {
         ui->brutal_u_speed->setText(Int2String(mux->brutal->up_mbps));
     }
 
-    auto old = ui->bean->layout()->itemAt(0)->widget();
-    ui->bean->layout()->removeWidget(old);
     innerWidget->layout()->setContentsMargins(0, 0, 0, 0);
-    ui->bean->layout()->addWidget(innerWidget);
+    ui->bean_scroll->setWidget(innerWidget); // deletes the previous editor
+    // setWidget() does not announce the new size hint, and cached hints refresh one nesting level per event loop
+    // pass, so invalidate up to the dialog before fitToScreen() measures it.
+    for (QWidget *w = ui->bean_scroll; w != this; w = w->parentWidget()) w->updateGeometry();
     ui->bean->setTitle(ent->outbound->DisplayType());
-    delete old;
 
     const auto innerTabOrder = collectTabOrder(this, innerWidget);
     if (!innerTabOrder.isEmpty() && innerTabOrderIndex >= 0 && innerTabOrderIndex <= outerTabOrder.size()) {
@@ -735,8 +745,7 @@ void DialogEditProfile::typeSelected(const QString &newType) {
 
     editor_cache_updated_impl();
     runOnThread([=,this] {
-        adjustSize();
-        adjustPosition(mainwindow);
+        fitToScreen();
         if (isHidden()) show();
     }, this);
 }


### PR DESCRIPTION
The edit profile dialog takes its minimum height from its content, so an editor taller than the screen opens with OK and Cancel below the bottom edge and cannot be shrunk, as the WireGuard form did on a 768 px display. f340000b made that form shorter, but the window still cannot be resized below any editor.

The editor now sits in a scroll area whose size hint follows its content (QScrollArea's own is capped at 36x24 font cells), the dialog sizes itself to the work area instead of adjustSize(), and the layout is invalidated after setWidget(). uic passes, the project builds on Windows with Qt 6.10, and an offscreen check shows a 40-row editor fitting a 768 px work area with the buttons visible.

Closes #1825
