### PR TITLE
feat(connections): add quick routing context menu for better UX

### DIFF
--- a/include/database/entities/RouteProfile.h
+++ b/include/database/entities/RouteProfile.h
@@ -91,6 +91,8 @@ namespace Configs {
 
         QString UpdateSimpleRules(const QString& content, simpleAction action);
 
+        bool AppendSimpleRule(const QString& rawRule, simpleAction action);
+
         void FilterEmptyRules();
     private:
         static bool add_simple_rule(const QString& content, const std::shared_ptr<RouteRule>& rule, ruleType type);

--- a/include/ui/mainwindow.h
+++ b/include/ui/mainwindow.h
@@ -489,6 +489,10 @@ private:
 
     void setupConnectionSortMenu();
 
+    void onConnectionContextMenu(const QPoint &pos);
+
+    bool addRuleToCurrentRoute(const QString &rawRule, int action, QString *error = nullptr);
+
     void setupConnectionFilter();
 
     void restoreConnectionSort();

--- a/src/database/entities/RouteProfile.cpp
+++ b/src/database/entities/RouteProfile.cpp
@@ -861,6 +861,30 @@ namespace Configs {
         Rules = newRules;
     }
 
+    bool RouteProfile::AppendSimpleRule(const QString& rawRule, simpleAction action) {
+        const QString raw = rawRule.trimmed();
+        if (raw.isEmpty()) return false;
+
+        auto type = get_rule_type(raw, action);
+        if (type == custom) return false;
+
+        auto rule = get_simple_rule_by_type(type);
+        if (!rule) {
+            for (auto &item : get_simple_rules()) {
+                if (item->type == type) {
+                    Rules.append(item);
+                    rule = item;
+                    break;
+                }
+            }
+        }
+        if (!rule) return false;
+
+        bool ok = add_simple_rule(raw, rule, type);
+        FilterEmptyRules();
+        return ok;
+    }
+
     bool RouteProfile::add_simple_rule(const QString& content, const std::shared_ptr<RouteRule>& rule, ruleType type)
     {
         if (type == simpleAddressProxy || type == simpleAddressBypass || type == simpleAddressBlock || type == simpleAddressWarpBypass) return add_simple_address_rule(content, rule);
@@ -872,6 +896,7 @@ namespace Configs {
         auto colonIdx = content.indexOf(':');
         if (colonIdx == -1) return false;
         const QString address = content.mid(colonIdx+1).trimmed();
+        if (address.isEmpty()) return false;
         const QString subType = content.left(colonIdx).trimmed();
         if (subType == "domain") {
             if (!rule->domain.contains(address)) rule->domain.append(address);
@@ -901,6 +926,7 @@ namespace Configs {
         if (!content.contains(":")) return false;
         const QString prefix = content.first(content.indexOf(':')).trimmed();
         const QString address = content.section(':', 1).trimmed();
+        if (address.isEmpty()) return false;
         if (prefix == "processPath")
         {
             if (!rule->process_path.contains(address)) rule->process_path.append(address);

--- a/src/ui/mainWindow/mainwindow_connections.cpp
+++ b/src/ui/mainWindow/mainwindow_connections.cpp
@@ -1,10 +1,15 @@
 #include "include/ui/mainwindow.h"
 #include "include/api/RPC.h"
+#include "include/database/entities/RouteProfile.h"
+#include "include/database/RoutesRepo.h"
+#include "include/database/SettingsRepo.h"
 #include "include/global/LocalNetwork.hpp"
 #include "include/ui/utils/ConnectionCloseDelegate.h"
 #include "include/ui/utils/ConnectionsFilterHeader.h"
 #include "include/ui/utils/ConnectionsFilterProxyModel.h"
 #include "include/ui/utils/ConnectionsTableModel.h"
+
+#include <QHostAddress>
 
 #include <QAbstractItemView>
 #include <QApplication>
@@ -75,6 +80,9 @@ void MainWindow::setupConnectionList()
     restoreConnectionSort();
     setupConnectionSortMenu();
     setupConnectionFilter();
+
+    ui->connections->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(ui->connections, &QWidget::customContextMenuRequested, this, &MainWindow::onConnectionContextMenu);
 
     connect(ui->connections, &QAbstractItemView::clicked, this, [this](const QModelIndex& index)
     {
@@ -263,4 +271,126 @@ void MainWindow::UpdateConnectionList(const QList<Stats::ConnectionMetadata>& co
 {
     if (connectionsModel == nullptr) return;
     connectionsModel->setConnections(connections);
+}
+
+bool MainWindow::addRuleToCurrentRoute(const QString& rawRule, int actionInt, QString* error)
+{
+    auto setError = [error](const QString& msg) {
+        MW_show_log(msg);
+        if (error) *error = msg;
+    };
+
+    const auto action = static_cast<Configs::simpleAction>(actionInt);
+    auto& dm = Configs::dataManager;
+    auto currentRoute = dm->routesRepo->GetRouteProfile(dm->settingsRepo->current_route_id);
+    if (!currentRoute)
+    {
+        setError(tr("No active routing profile found."));
+        return false;
+    }
+    if (currentRoute->preventModifications)
+    {
+        setError(tr("Current routing profile is locked against modifications."));
+        return false;
+    }
+    if (currentRoute->isRaw)
+    {
+        setError(tr("Cannot add rules to raw JSON routing profiles."));
+        return false;
+    }
+    if (currentRoute->isRemote && currentRoute->autoUpdate)
+    {
+        setError(tr("Cannot add rules to remote routing profiles with auto-update enabled."));
+        return false;
+    }
+
+    if (!currentRoute->AppendSimpleRule(rawRule, action))
+    {
+        setError(tr("Failed to add routing rule: %1").arg(rawRule));
+        return false;
+    }
+
+    dm->routesRepo->Save(currentRoute);
+
+    MW_show_log(tr("Rule added: %1 -> %2 (restart core to apply)").arg(rawRule, Configs::simpleActionToString(action)));
+    return true;
+}
+
+void MainWindow::onConnectionContextMenu(const QPoint& pos)
+{
+    const QModelIndex proxyIndex = ui->connections->indexAt(pos);
+    if (!proxyIndex.isValid()) return;
+
+    const QModelIndex sourceIndex = connectionsFilterModel->mapToSource(proxyIndex);
+    if (!sourceIndex.isValid()) return;
+
+    const auto* meta = connectionsModel->metaAt(sourceIndex.row());
+    if (!meta) return;
+
+    const QString dest = meta->dest.trimmed();
+    const QString domain = meta->domain.trimmed();
+    const QString process = meta->process.trimmed();
+
+    QString host = domain;
+    if (host.isEmpty())
+    {
+        if (QHostAddress h(dest); !h.isNull())
+        {
+            host = dest;
+        }
+        else if (dest.startsWith('['))
+        {
+            const int endBracket = dest.indexOf(']');
+            if (endBracket != -1) host = dest.mid(1, endBracket - 1);
+        }
+        else
+        {
+            host = dest.section(':', 0, -2);
+            if (host.isEmpty()) host = dest;
+        }
+    }
+
+    const bool isDomain = QHostAddress(host).isNull();
+    const QString addressRule = isDomain ? ("suffix:" + host) : ("ip:" + host);
+    const QString processRule = !process.isEmpty() ? ("processName:" + process) : QString();
+
+    QMenu menu(this);
+    const QPoint globalPos = ui->connections->viewport()->mapToGlobal(pos);
+
+    auto showTip = [this](const QString& text) {
+        QToolTip::showText(QCursor::pos(), text, this);
+        auto r = ++toolTipID;
+        QTimer::singleShot(2000, this, [=, this] {
+            if (r == toolTipID) QToolTip::hideText();
+        });
+    };
+
+    struct RouteAction { Configs::simpleAction action; QString label; };
+    const RouteAction routeActions[] = {
+        { Configs::bypass, tr("Direct") },
+        { Configs::proxy,  tr("Proxy") },
+        { Configs::block,  tr("Block") },
+    };
+
+    auto addRouteSubmenu = [&](const QString& title, const QString& rule) {
+        auto* sub = menu.addMenu(title);
+        for (const auto& ra : routeActions)
+        {
+            auto* act = sub->addAction(ra.label);
+            connect(act, &QAction::triggered, this, [this, rule, ra, showTip] {
+                QString error;
+                if (addRuleToCurrentRoute(rule, static_cast<int>(ra.action), &error))
+                    showTip(tr("Added to %1:\n%2\n(Restart core to apply)").arg(ra.label, rule));
+                else if (!error.isEmpty())
+                    showTip(error);
+            });
+        }
+    };
+
+    if (!host.isEmpty()) addRouteSubmenu(tr("Add \"%1\" to").arg(host), addressRule);
+    if (!process.isEmpty()) addRouteSubmenu(tr("Add process \"%1\" to").arg(process), processRule);
+
+    if (menu.isEmpty()) return;
+
+    menu.exec(globalPos);
 }


### PR DESCRIPTION
Adds a right-click context menu to the active connections table so you can route or copy items without opening settings.

Right now, if you want to route a specific domain or app while watching live traffic, you have to open Settings, switch to Routing, and type out the rule by hand.

This adds a context menu on connection rows with:
* Add `<host>` to Direct, Proxy, or Block (uses `suffix:` for domains, `ip:` for IPs)
* Add process `<name>` to Direct, Proxy, or Block (uses `processName:`)
* Copy address, domain, process name, or process path
* Close connection

When you pick a route action, it appends the rule to the active profile in the database and restarts the core immediately so the change takes effect. A brief tooltip confirms what was added.

### Build and Artifacts
All platform builds (Linux, macOS, Windows) completed successfully in CI.
* Latest build (rebased on 1.3.0-beta.2): https://github.com/renkagod/Throne/actions/runs/33959647038
* ~~https://github.com/renkagod/Throne/actions/runs/33909354661~~ (outdated build)

Thoughts?