### PR TITLE
Stop profile names from setting the Route Profile dialog width

### DIFF
--- a/include/ui/setting/RouteItem.ui
+++ b/include/ui/setting/RouteItem.ui
@@ -243,6 +243,9 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::SizeAdjustPolicy::AdjustToMinimumContentsLengthWithIcon</enum>
+           </property>
           </widget>
          </item>
          <item>

--- a/src/ui/setting/RouteItem.cpp
+++ b/src/ui/setting/RouteItem.cpp
@@ -647,6 +647,7 @@ QWidget* RouteItem::makeAttributeEditorPage(const QString& attr) {
         case Configs::select: {
             auto* cb = new QComboBox(container);
             if (attr == QStringLiteral("outbound")) {
+                cb->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
                 cb->addItems(outbounds);
                 cb->setCurrentText(get_outbound_name(rule->outboundID));
                 connect(cb, &QComboBox::currentTextChanged, this, [this, cb] {


### PR DESCRIPTION
The Outbound editor in the Advanced tab is a QComboBox listing every profile as "[group] name". With Qt's default size adjust policy the longest item becomes the combo box's minimum width, and through the layouts the minimum width of the whole dialog. A long profile name therefore pushes the window past the screen edge, and repainting a window that wide is what freezes the rule selection and the Outbound tab.

The outbound combo box, and the Endpoints picker that is filled the same way, now use AdjustToMinimumContentsLengthWithIcon, so the dialog keeps its own size while the popup still widens to the longest entry. In a standalone copy of RouteItem.ui a 4000-character item pushed the minimum width to about 45000 px; with the change the dialog keeps its normal width. uic and a build of the touched objects pass.

Closes #1846
