### PR TITLE
ui: add macOS window shortcuts (Cmd+W, Cmd+M) and profile start on Enter

### DIFF
--- a/src/ui/mainWindow/mainwindow_setup.cpp
+++ b/src/ui/mainWindow/mainwindow_setup.cpp
@@ -151,6 +151,19 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     }
     themeManager()->ApplyTheme(Configs::dataManager->settingsRepo->theme);
     ui->setupUi(this);
+#ifdef Q_OS_MACOS
+    auto hideShortcuts = ui->actionHide_window->shortcuts();
+    const QKeySequence closeSeq(Qt::MetaModifier | Qt::Key_W);
+    if (!hideShortcuts.contains(closeSeq)) {
+        hideShortcuts.append(closeSeq);
+        ui->actionHide_window->setShortcuts(hideShortcuts);
+    }
+
+    auto *minimizeShortcut = new QShortcut(QKeySequence(Qt::MetaModifier | Qt::Key_M), this);
+    connect(minimizeShortcut, &QShortcut::activated, this, [this]() {
+        showMinimized();
+    });
+#endif
 
     setActionsData();
     loadShortcuts();

--- a/src/ui/utils/ProfilesTableView.cpp
+++ b/src/ui/utils/ProfilesTableView.cpp
@@ -56,6 +56,10 @@ void ProfilesTableView::keyPressEvent(QKeyEvent *event) {
         event->accept();
         return;
     }
+    if (event->key() == Qt::Key_Return || event->key() == Qt::Key_Enter) {
+        event->ignore();
+        return;
+    }
     QTableView::keyPressEvent(event);
 }
 


### PR DESCRIPTION
### Description
This PR adds macOS window management shortcuts and fixes starting profiles with the Enter key:

1. **Cmd+W**: hides the main window and transforms the process to a background UI element (hiding it from the macOS Dock).
2. **Cmd+M**: standard macOS window minimization to the Dock (`showMinimized()`).
3. **Enter / Return**: fixes `ProfilesTableView` intercepting Return/Enter so that pressing Enter directly starts/selects the highlighted profile in the table.