### PR TITLE
Fix root-owned cache.db when the core runs setuid

### DIFF
--- a/core/server/internal/boxmain/cmd_run.go
+++ b/core/server/internal/boxmain/cmd_run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sagernet/sing-box/option"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/json"
+	"github.com/sagernet/sing/service/filemanager"
 	"github.com/spf13/cobra"
 )
 
@@ -96,7 +97,27 @@ func Create(configContent []byte, onCreated func(*boxbox.Box)) (*boxbox.Box, con
 		cancel()
 		return nil, nil, E.Cause(err, "start service")
 	}
+	adoptCacheFile(ctx, options)
 	return instance, cancel, nil
+}
+
+// filemanager.WithDefault compares the target against the real uid, which under setuid is already the user, so it never chowns.
+func adoptCacheFile(ctx context.Context, options *option.Options) {
+	if os.Geteuid() != 0 || os.Getuid() == 0 {
+		return
+	}
+	experimental := options.Experimental
+	if experimental == nil || experimental.CacheFile == nil || !experimental.CacheFile.Enabled {
+		return
+	}
+	path := experimental.CacheFile.Path
+	if path == "" {
+		path = "cache.db"
+	}
+	path = filemanager.BasePath(ctx, path)
+	if err := os.Lchown(path, os.Getuid(), os.Getgid()); err != nil {
+		log.Warn(E.Cause(err, "chown cache file"))
+	}
 }
 
 func run() error {


### PR DESCRIPTION
On Linux and macOS the core runs setuid root, so sing-box creates cache.db as root and the GUI user can no longer delete it, the second problem reported in #1841. sing-box's file manager can hand new files to another user, but only when the requested owner differs from the process's real uid, and under setuid the real uid already is the user, so it never chowns. That is why the SUDO_UID path in newBoxContext does not cover this launch.

After the box starts, chown the cache file to the real uid/gid when the effective uid is root, as adoptExtracted already does for the dashboard tree. An existing root-owned cache.db is adopted on the next start too. Growth is untouched: bbolt never shrinks its file, so that needs a compaction step.

Part of #1841
