### PR TITLE
feat(sub): add subscription userinfo parsing, profile-update-interval, and implemented SubscriptionInfoCard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ set(PROJECT_SOURCES
         src/global/HTTPRequestHelper.cpp
         src/global/DeviceDetailsHelper.cpp
         src/global/CountryHelper.cpp
+        include/global/LocalNetwork.hpp
+        src/global/LocalNetwork.cpp
         include/global/OTP.hpp
         src/global/OTP.cpp
         include/global/OtpPlaceholder.hpp
@@ -182,6 +184,8 @@ set(PROJECT_SOURCES
         src/ui/widget/TrayProfileSelector.cpp
         include/ui/widget/TrayOtpCodes.hpp
         src/ui/widget/TrayOtpCodes.cpp
+        include/ui/widget/SubscriptionInfoCard.hpp
+        src/ui/widget/SubscriptionInfoCard.cpp
         include/ui/widget/json/JsonTree.h
         src/ui/widget/json/JsonTree.cpp
         include/ui/widget/json/JsonValidator.h

--- a/include/configs/sub/GroupUpdater.hpp
+++ b/include/configs/sub/GroupUpdater.hpp
@@ -22,6 +22,8 @@ namespace Subscription {
 
         void RefreshAll(bool onlyAllowed = false);
 
+        void CheckAutoUpdate();
+
         void SubscribeUrl(const QString &url, const Finish &finish = nullptr);
 
         void ImportUrl(const QString &url, const Finish &finish = nullptr);
@@ -54,5 +56,6 @@ namespace Subscription {
         bool running = false;
     };
 
+    int ParseUpdateInterval(const QString &headerStr);
     GroupUpdater *updater();
 } // namespace Subscription

--- a/include/database/entities/Group.h
+++ b/include/database/entities/Group.h
@@ -1,12 +1,39 @@
 #pragma once
+#include <QDateTime>
 #include <QList>
 #include <QMutex>
 #include <QString>
+#include <algorithm>
 
 #include "include/ui/group/GroupSort.hpp"
 
 namespace Configs
 {
+    struct SubUserInfo {
+        bool valid = false;
+        qint64 upload = 0;       // Bytes
+        qint64 download = 0;     // Bytes
+        qint64 total = 0;        // Bytes (0 = unlimited)
+        qint64 expire = 0;       // Unix epoch seconds (0 = no expiry)
+        QString title;           // Profile Title (e.g. "WindyDay")
+        QString web_url;         // Website / Dashboard URL
+        QString support_url;     // Support / Telegram URL
+        QString announce;        // Announcement text
+
+        [[nodiscard]] qint64 used() const { return upload + download; }
+        [[nodiscard]] qint64 remaining() const { return (total > used()) ? (total - used()) : 0; }
+        [[nodiscard]] double percentUsed() const {
+            if (total <= 0) return 0.0;
+            return std::clamp((static_cast<double>(used()) / static_cast<double>(total)) * 100.0, 0.0, 100.0);
+        }
+        [[nodiscard]] bool isExpired() const {
+            if (expire <= 0) return false;
+            return QDateTime::currentSecsSinceEpoch() > expire;
+        }
+    };
+
+    SubUserInfo ParseSubUserInfo(const QString &info);
+
     enum class testBy : int {
         latency = 0,
         dlSpeed,
@@ -43,6 +70,7 @@ namespace Configs
         QString url = "";
         QString info = "";
         qint64 sub_last_update = 0;
+        int sub_update_interval = 0; // In hours (0 = Default/Auto, >0 = custom)
         int front_proxy_id = -1;
         int landing_proxy_id = -1;
 
@@ -58,6 +86,8 @@ namespace Configs
         QList<std::pair<int, int>> selectedProfilesIdIdxPairs;
 
         Group() = default;
+
+        [[nodiscard]] SubUserInfo GetSubUserInfo() const { return ParseSubUserInfo(info); }
 
         void clearCalculatedColumnWidth();
 

--- a/include/ui/group/dialog_edit_group.ui
+++ b/include/ui/group/dialog_edit_group.ui
@@ -121,7 +121,24 @@
       <item row="0" column="1">
        <widget class="MyLineEdit" name="url"/>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_update_interval">
+        <property name="text">
+         <string>Update Interval</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
+       <widget class="QSpinBox" name="sub_update_interval">
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>720</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
        <widget class="QCheckBox" name="skip_auto_update">
         <property name="text">
          <string>Skip automatic update</string>
@@ -174,6 +191,7 @@
   <tabstop>name</tabstop>
   <tabstop>type</tabstop>
   <tabstop>url</tabstop>
+  <tabstop>sub_update_interval</tabstop>
   <tabstop>skip_auto_update</tabstop>
   <tabstop>copy_links</tabstop>
   <tabstop>copy_links_nkr</tabstop>

--- a/include/ui/mainwindow.h
+++ b/include/ui/mainwindow.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <QMainWindow>
+#include <QStackedWidget>
+#include "include/ui/widget/SubscriptionInfoCard.hpp"
+
 #include <include/global/HTTPRequestHelper.hpp>
 #ifndef Q_MOC_RUN
 #include <core/server/gen/libcore.pb.h>
@@ -279,6 +282,9 @@ private:
     std::atomic<qint64> lastUpdatedMs = QDateTime::currentMSecsSinceEpoch();
     DataViewHtmlGenerator dataViewHtmlGenerator_;
 
+    QStackedWidget *m_topBarStack = nullptr;       
+    SubscriptionInfoCard *m_subInfoCard = nullptr; 
+
     QList<QShortcut*> hiddenMenuShortcuts;
 
     QString addressFilterString;
@@ -496,6 +502,8 @@ private:
     void applyConnectionSort(Stats::ConnectionSort sort);
 
     void applyConnectionFilters();
+
+    void syncConnectionSourceColumn();
 
     // Rows are rewritten on every poll, so ids are read at click time, never captured.
     void closeConnections(const QStringList &ids);

--- a/include/ui/widget/SubscriptionInfoCard.hpp
+++ b/include/ui/widget/SubscriptionInfoCard.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <QFrame>
+#include <memory>
+
+namespace Configs {
+    class Group;
+}
+
+class QLabel;
+class QProgressBar;
+class QToolButton;
+class QResizeEvent;
+
+class SubscriptionInfoCard : public QFrame {
+    Q_OBJECT
+public:
+    explicit SubscriptionInfoCard(QWidget *parent = nullptr);
+    ~SubscriptionInfoCard() override = default;
+
+    void setGroup(const std::shared_ptr<Configs::Group> &group);
+    void applyTheme();
+    [[nodiscard]] bool hasSubscription() const;
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    void setupUi();
+    void updateData();
+    void updateAnnouncementLayout();
+
+    std::shared_ptr<Configs::Group> m_group;
+    QString m_fullAnnounce;
+
+    // Line 1: Title & Expiry & Action buttons
+    QLabel *m_titleLabel = nullptr;
+    QLabel *m_expiryIcon = nullptr;
+    QLabel *m_expiryLabel = nullptr;
+    QToolButton *m_btnPortal = nullptr;
+    QToolButton *m_btnSupport = nullptr;
+
+    // Line 2: Progress bar 
+    QProgressBar *m_progressBar = nullptr;
+
+    // Line 3: Announcement footer
+    QFrame *m_bottomRow = nullptr;
+    QLabel *m_bottomLabel = nullptr;
+    QToolButton *m_btnAnnounceMore = nullptr;
+};

--- a/src/configs/sub/GroupUpdater.cpp
+++ b/src/configs/sub/GroupUpdater.cpp
@@ -11,6 +11,7 @@
 #include <QDateTime>
 #include <QJsonDocument>
 #include <QMutexLocker>
+#include <QRegularExpression>
 #include <QUrl>
 
 #include <algorithm>
@@ -122,7 +123,45 @@ namespace Subscription {
             const auto group = Configs::dataManager->groupsRepo->GetGroup(gid);
             return group == nullptr ? Int2String(gid) : group->name;
         }
+
+        QString decodeHeaderValue(const QString &raw) {
+            QString str = raw.trimmed();
+            if (str.startsWith("base64:", Qt::CaseInsensitive)) {
+                QString payload = str.mid(7).trimmed();
+                if (payload.isEmpty()) return QString();
+                QByteArray decoded = QByteArray::fromBase64(payload.toUtf8(), 
+                    QByteArray::Base64UrlEncoding | QByteArray::AbortOnBase64DecodingErrors);
+                if (decoded.isEmpty()) {
+                    decoded = QByteArray::fromBase64(payload.toUtf8());
+                }
+                if (!decoded.isEmpty()) return QString::fromUtf8(decoded).trimmed();
+                return QString();
+            }
+            return str;
+        }
     } // namespace
+
+    int ParseUpdateInterval(const QString &headerStr) {
+        if (headerStr.trimmed().isEmpty()) return 0;
+        QString s = headerStr.trimmed().remove('"').remove('\'').toLower();
+        bool ok = false;
+        if (s.endsWith("h")) {
+            int h = s.chopped(1).toInt(&ok);
+            if (ok && h > 0) return h;
+        } else if (s.endsWith("d")) {
+            int d = s.chopped(1).toInt(&ok);
+            if (ok && d > 0) return d * 24;
+        } else if (s.endsWith("s")) {
+            int sec = s.chopped(1).toInt(&ok);
+            if (ok && sec > 0) return std::max(1, sec / 3600);
+        }
+        int num = s.toInt(&ok);
+        if (ok && num > 0) {
+            if (num > 1000) return std::max(1, num / 3600);
+            return num;
+        }
+        return 0;
+    }
 
     GroupUpdater *updater() {
         static auto *instance = new GroupUpdater;
@@ -162,6 +201,31 @@ namespace Subscription {
                 refresh(gid, false);
                 emit asyncUpdateCallback(gid);
             }});
+        }
+    }
+
+    void GroupUpdater::CheckAutoUpdate() {
+        const qint64 now = QDateTime::currentSecsSinceEpoch();
+        const auto globalMinutes = Configs::dataManager->settingsRepo->sub_auto_update;
+        const bool globalEnabled = globalMinutes >= 30;
+        const auto tabOrder = Configs::dataManager->groupsRepo->GetGroupsTabOrder();
+
+        for (const int gid : tabOrder) {
+            const auto group = Configs::dataManager->groupsRepo->GetGroup(gid);
+            if (group == nullptr || group->url.isEmpty() || group->archive || group->skip_auto_update) continue;
+
+            qint64 intervalSecs = 0;
+            if (group->sub_update_interval > 0) {
+                intervalSecs = static_cast<qint64>(group->sub_update_interval) * 3600;
+            } else if (globalEnabled) {
+                intervalSecs = static_cast<qint64>(globalMinutes) * 60;
+            }
+
+            if (intervalSecs <= 0) continue;
+
+            if (group->sub_last_update <= 0 || (now - group->sub_last_update) >= intervalSecs) {
+                RefreshGroup(gid, nullptr, false);
+            }
         }
     }
 
@@ -254,8 +318,56 @@ namespace Subscription {
             return false;
         }
         body = std::move(resp.data);
+
+        // 1. Extract from HTTP response headers
         userInfo = NetworkRequestHelper::GetHeader(resp.header, "Subscription-UserInfo");
+        if (userInfo.isEmpty()) {
+            userInfo = NetworkRequestHelper::GetHeader(resp.header, "Subscription-Userinfo");
+        }
+
+        QString intervalHeader = NetworkRequestHelper::GetHeader(resp.header, "profile-update-interval");
+        if (intervalHeader.isEmpty()) {
+            intervalHeader = NetworkRequestHelper::GetHeader(resp.header, "x-profile-update-interval");
+        }
+        QString profileTitle = decodeHeaderValue(NetworkRequestHelper::GetHeader(resp.header, "Profile-Title"));
+        QString webPageUrl = NetworkRequestHelper::GetHeader(resp.header, "Profile-Web-Page-Url");
+        QString supportUrl = NetworkRequestHelper::GetHeader(resp.header, "Support-Url");
+        if (supportUrl.isEmpty()) supportUrl = NetworkRequestHelper::GetHeader(resp.header, "support-url");
+        QString announceMsg = decodeHeaderValue(NetworkRequestHelper::GetHeader(resp.header, "Announce"));
+
+        // 2. In-body comments fallback (#subscription-userinfo:, #profile-title:, etc.)
+        for (const auto &line : QString::fromUtf8(body).split('\n')) {
+            const auto trimmed = line.trimmed();
+            if (trimmed.isEmpty()) continue;
+            if (!trimmed.startsWith('#') && !trimmed.startsWith("//")) break;
+            auto clean = trimmed.mid(trimmed.startsWith("//") ? 2 : 1).trimmed();
+
+            if (userInfo.isEmpty() && clean.startsWith("subscription-userinfo:", Qt::CaseInsensitive)) {
+                userInfo = clean.section(':', 1).trimmed();
+            } else if (intervalHeader.isEmpty() && clean.startsWith("profile-update-interval:", Qt::CaseInsensitive)) {
+                intervalHeader = clean.section(':', 1).trimmed();
+            } else if (profileTitle.isEmpty() && clean.startsWith("profile-title:", Qt::CaseInsensitive)) {
+                profileTitle = decodeHeaderValue(clean.section(':', 1).trimmed());
+            } else if (webPageUrl.isEmpty() && clean.startsWith("profile-web-page-url:", Qt::CaseInsensitive)) {
+                webPageUrl = clean.section(':', 1).trimmed();
+            } else if (supportUrl.isEmpty() && clean.startsWith("support-url:", Qt::CaseInsensitive)) {
+                supportUrl = clean.section(':', 1).trimmed();
+            } else if (announceMsg.isEmpty() && (clean.startsWith("announce:", Qt::CaseInsensitive) || clean.startsWith("notice:", Qt::CaseInsensitive))) {
+                announceMsg = decodeHeaderValue(clean.section(':', 1).trimmed());
+            }
+        }
+
+        int intervalHours = ParseUpdateInterval(intervalHeader);
+        if (intervalHours > 0) userInfo += (userInfo.isEmpty() ? "" : "; ") + QString("interval=%1").arg(intervalHours);
+        if (!profileTitle.isEmpty()) userInfo += (userInfo.isEmpty() ? "" : "; ") + QString("title=") + profileTitle;
+        if (!webPageUrl.isEmpty()) userInfo += (userInfo.isEmpty() ? "" : "; ") + QString("web_url=") + webPageUrl;
+        if (!supportUrl.isEmpty()) userInfo += (userInfo.isEmpty() ? "" : "; ") + QString("support_url=") + supportUrl;
+        if (!announceMsg.isEmpty()) userInfo += (userInfo.isEmpty() ? "" : "; ") + QString("announce=") + announceMsg;
+
         MW_show_log("<<<<<<<< " + QObject::tr("Subscription request fininshed: %1").arg(name));
+        if (intervalHours > 0) {
+            MW_show_log(QObject::tr("Subscription server update interval: %1 hour(s)").arg(intervalHours));
+        }
         return true;
     }
 
@@ -284,10 +396,29 @@ namespace Subscription {
 
         QByteArray body;
         QString userInfo;
-        if (!fetch(group->url.trimmed(), group->name, body, userInfo)) return;
+        if (!fetch(group->url.trimmed(), group->name, body, userInfo)) {
+            group->sub_last_update = QDateTime::currentSecsSinceEpoch();
+            groupsRepo->Save(group);
+            return;
+        }
 
-        group->sub_last_update = QDateTime::currentMSecsSinceEpoch() / 1000;
-        group->info = userInfo;
+        group->sub_last_update = QDateTime::currentSecsSinceEpoch();
+        if (!userInfo.isEmpty()) {
+            group->info = userInfo;
+        }
+
+        auto subInfo = group->GetSubUserInfo();
+        static const QRegularExpression intervalRe(R"((?:^|[;\s])interval=(\d+))", QRegularExpression::CaseInsensitiveOption);
+        auto mInterval = intervalRe.match(userInfo);
+        if (mInterval.hasMatch() && group->sub_update_interval == 0) {
+            group->sub_update_interval = mInterval.captured(1).toInt();
+        }
+
+        if (!subInfo.title.isEmpty() && (group->name.isEmpty() || group->name == QUrl(group->url).host())) {
+            group->name = subInfo.title;
+            MW_dialog_message(MwMessage::GroupsChanged, {});
+        }
+
         groupsRepo->Save(group);
 
         // Auto selectors are local state, not servers the remote sent: keep them out of the diff.

--- a/src/database/GroupsRepo.cpp
+++ b/src/database/GroupsRepo.cpp
@@ -16,7 +16,7 @@ namespace Configs {
         createTables();
     }
 
-    void GroupsRepo::createTables() const {
+void GroupsRepo::createTables() const {
         db.exec(R"(
             CREATE TABLE IF NOT EXISTS groups (
                 id INTEGER PRIMARY KEY,
@@ -26,6 +26,7 @@ namespace Configs {
                 url TEXT,
                 info TEXT,
                 sub_last_update INTEGER NOT NULL DEFAULT 0,
+                sub_update_interval INTEGER NOT NULL DEFAULT 0,
                 front_proxy_id INTEGER NOT NULL DEFAULT -1,
                 landing_proxy_id INTEGER NOT NULL DEFAULT -1,
                 column_width_json TEXT,
@@ -40,9 +41,11 @@ namespace Configs {
                 updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
             )
         )");
-        // Migrate existing databases created before type_sort_by was added.
+        // Migrate existing databases created before type_sort_by or sub_update_interval was added.
         if (!groupsColumnExists("type_sort_by"))
             db.exec("ALTER TABLE groups ADD COLUMN type_sort_by INTEGER NOT NULL DEFAULT 0");
+        if (!groupsColumnExists("sub_update_interval"))
+            db.exec("ALTER TABLE groups ADD COLUMN sub_update_interval INTEGER NOT NULL DEFAULT 0");
 
         db.exec(R"(
             CREATE TABLE IF NOT EXISTS groups_order (
@@ -72,6 +75,7 @@ namespace Configs {
         json["url"] = group->url;
         json["info"] = group->info;
         json["sub_last_update"] = static_cast<qint64>(group->sub_last_update);
+        json["sub_update_interval"] = group->sub_update_interval;
         json["front_proxy_id"] = group->front_proxy_id;
         json["landing_proxy_id"] = group->landing_proxy_id;
         json["column_width"] = QListInt2QJsonArray(group->column_width);
@@ -96,6 +100,7 @@ namespace Configs {
         group->url = json["url"].toString();
         group->info = json["info"].toString();
         group->sub_last_update = json["sub_last_update"].toVariant().toLongLong();
+        group->sub_update_interval = json["sub_update_interval"].toInt(0);
         group->front_proxy_id = json["front_proxy_id"].toInt();
         group->landing_proxy_id = json["landing_proxy_id"].toInt();
         group->column_width = QJsonArray2QListInt(json["column_width"].toArray());
@@ -121,15 +126,16 @@ namespace Configs {
         
         db.exec(R"(
             INSERT INTO groups
-            (id, archive, skip_auto_update, auto_clear_unavailable, name, url, info, sub_last_update,
+            (id, archive, skip_auto_update, auto_clear_unavailable, name, url, info, sub_last_update, sub_update_interval,
              front_proxy_id, landing_proxy_id,
              column_width_json, profiles_json, scroll_last_profile, test_sort_by, traffic_sort_by, test_items_to_show,
              type_sort_by)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 archive = excluded.archive, skip_auto_update = excluded.skip_auto_update,
                 auto_clear_unavailable = excluded.auto_clear_unavailable, name = excluded.name,
                 url = excluded.url, info = excluded.info, sub_last_update = excluded.sub_last_update,
+                sub_update_interval = excluded.sub_update_interval,
                 front_proxy_id = excluded.front_proxy_id, landing_proxy_id = excluded.landing_proxy_id,
                 column_width_json = excluded.column_width_json, profiles_json = excluded.profiles_json,
                 scroll_last_profile = excluded.scroll_last_profile, test_sort_by = excluded.test_sort_by,
@@ -145,6 +151,7 @@ namespace Configs {
             group->url.toStdString(),
             group->info.toStdString(),
             static_cast<long long>(group->sub_last_update),
+            group->sub_update_interval,
             group->front_proxy_id,
             group->landing_proxy_id,
             columnWidthJson.toStdString(),
@@ -159,7 +166,7 @@ namespace Configs {
 
     std::shared_ptr<Group> GroupsRepo::loadFromDatabase(int id) const {
         auto query = db.query(R"(
-            SELECT id, archive, skip_auto_update, auto_clear_unavailable, name, url, info, sub_last_update,
+            SELECT id, archive, skip_auto_update, auto_clear_unavailable, name, url, info, sub_last_update, sub_update_interval,
                    front_proxy_id, landing_proxy_id,
                    column_width_json, profiles_json, scroll_last_profile, test_sort_by, traffic_sort_by, test_items_to_show,
                    type_sort_by
@@ -178,10 +185,11 @@ namespace Configs {
         json["url"] = QString::fromStdString(query->getColumn(5).getText());
         json["info"] = QString::fromStdString(query->getColumn(6).getText());
         json["sub_last_update"] = static_cast<qint64>(query->getColumn(7).getInt64());
-        json["front_proxy_id"] = query->getColumn(8).getInt();
-        json["landing_proxy_id"] = query->getColumn(9).getInt();
+        json["sub_update_interval"] = query->getColumn(8).getInt();
+        json["front_proxy_id"] = query->getColumn(9).getInt();
+        json["landing_proxy_id"] = query->getColumn(10).getInt();
 
-        QString columnWidthJsonStr = QString::fromStdString(query->getColumn(10).getText());
+        QString columnWidthJsonStr = QString::fromStdString(query->getColumn(11).getText());
         if (!columnWidthJsonStr.isEmpty()) {
             QJsonDocument columnWidthDoc = QJsonDocument::fromJson(columnWidthJsonStr.toUtf8());
             if (!columnWidthDoc.isNull() && columnWidthDoc.isArray()) {
@@ -189,7 +197,7 @@ namespace Configs {
             }
         }
         
-        QString profilesJsonStr = QString::fromStdString(query->getColumn(11).getText());
+        QString profilesJsonStr = QString::fromStdString(query->getColumn(12).getText());
         if (!profilesJsonStr.isEmpty()) {
             QJsonDocument profilesDoc = QJsonDocument::fromJson(profilesJsonStr.toUtf8());
             if (!profilesDoc.isNull() && profilesDoc.isArray()) {
@@ -197,11 +205,11 @@ namespace Configs {
             }
         }
 
-        json["scroll_last_profile"] = query->getColumn(12).getInt();
-        json["test_sort_by"] = query->getColumn(13).getInt();
-        json["traffic_sort_by"] = query->getColumn(14).getInt();
-        json["test_items_to_show"] = query->getColumn(15).getInt();
-        json["type_sort_by"] = query->getColumn(16).getInt();
+        json["scroll_last_profile"] = query->getColumn(13).getInt();
+        json["test_sort_by"] = query->getColumn(14).getInt();
+        json["traffic_sort_by"] = query->getColumn(15).getInt();
+        json["test_items_to_show"] = query->getColumn(16).getInt();
+        json["type_sort_by"] = query->getColumn(17).getInt();
 
         auto group = groupFromJson(json);
         // Refreshes could map several identical servers onto one id, leaving it in the persisted list once per server (#1775).

--- a/src/database/entities/Group.cpp
+++ b/src/database/entities/Group.cpp
@@ -2,9 +2,80 @@
 
 #include "include/database/ProfilesRepo.h"
 #include "include/global/Configs.hpp"
+#include <QRegularExpression> 
 
 namespace Configs
 {
+    SubUserInfo ParseSubUserInfo(const QString &info) {
+        SubUserInfo result;
+        if (info.trimmed().isEmpty()) return result;
+
+        static const QRegularExpression totalRe(R"((?:^|[;,\s])total=(\d+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression uploadRe(R"((?:^|[;,\s])upload=(\d+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression downloadRe(R"((?:^|[;,\s])download=(\d+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression expireRe(R"((?:^|[;,\s])expire=(\d+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression titleRe(R"((?:^|[;\s])title=([^;\n]+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression webUrlRe(R"((?:^|[;\s])(?:web_url|url)=([^;\n\s]+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression supportUrlRe(R"((?:^|[;\s])support_url=([^;\n\s]+))", QRegularExpression::CaseInsensitiveOption);
+        static const QRegularExpression announceRe(R"((?:^|[;\s])announce=(.+)$)", QRegularExpression::CaseInsensitiveOption);
+
+        auto mTotal = totalRe.match(info);
+        if (mTotal.hasMatch()) {
+            result.total = mTotal.captured(1).toLongLong();
+            result.valid = true;
+        }
+
+        auto mUpload = uploadRe.match(info);
+        if (mUpload.hasMatch()) {
+            result.upload = mUpload.captured(1).toLongLong();
+            result.valid = true;
+        }
+
+        auto mDownload = downloadRe.match(info);
+        if (mDownload.hasMatch()) {
+            result.download = mDownload.captured(1).toLongLong();
+            result.valid = true;
+        }
+
+        auto mExpire = expireRe.match(info);
+        if (mExpire.hasMatch()) {
+            result.expire = mExpire.captured(1).toLongLong();
+            if (result.expire > 1000000000000LL) {
+                result.expire /= 1000; // Convert ms to seconds
+            }
+            result.valid = true;
+        }
+
+        auto mTitle = titleRe.match(info);
+        if (mTitle.hasMatch()) {
+            result.title = mTitle.captured(1).trimmed();
+            result.valid = true;
+        }
+
+        auto mWeb = webUrlRe.match(info);
+        if (mWeb.hasMatch()) {
+            result.web_url = mWeb.captured(1).trimmed();
+            result.valid = true;
+        }
+
+        auto mSup = supportUrlRe.match(info);
+        if (mSup.hasMatch()) {
+            result.support_url = mSup.captured(1).trimmed();
+            result.valid = true;
+        }
+
+        auto mAnnounce = announceRe.match(info);
+        if (mAnnounce.hasMatch()) {
+            QString ann = mAnnounce.captured(1).trimmed();
+            if (!ann.isEmpty() && ann.compare("base64:", Qt::CaseInsensitive) != 0) {
+                result.announce = ann;
+                result.valid = true;
+            }
+        }
+
+        return result;
+    }
+
     void Group::clearCalculatedColumnWidth() {
         calculated_column_width.clear();
     }

--- a/src/ui/group/GroupItem.cpp
+++ b/src/ui/group/GroupItem.cpp
@@ -9,44 +9,38 @@
 #include "include/database/GroupsRepo.h"
 #include "include/ui/mainwindow.h"
 
+QString ParseSubInfo(const QString &info, int updateIntervalHours = 0) {
+    auto sub = Configs::ParseSubUserInfo(info);
+    if (!sub.valid) return "";
 
-QString ParseSubInfo(const QString &info) {
-    if (info.trimmed().isEmpty()) return "";
+    QStringList parts;
+    QString usedStr = ReadableSize(sub.used());
+    QString totalStr = (sub.total > 0) ? ReadableSize(sub.total) : QString::fromUtf8("\u221E");
+    QString remainStr = (sub.total > 0) ? ReadableSize(sub.remaining()) : QString::fromUtf8("\u221E");
 
-    long long used = 0;
-    long long total = 0;
-    long long expire = 0;
+    parts << QObject::tr("Used: %1 / %2 (%3 remain)").arg(usedStr, totalStr, remainStr);
 
-    static const QRegularExpression re(
-        R"((total|upload|download|expire)=([0-9]+))");
-
-    auto it = re.globalMatch(info);
-
-    bool hasTotal = false;
-
-    while (it.hasNext()) {
-        const auto match = it.next();
-        const QStringView key = match.capturedView(1);
-        const long long value = match.capturedView(2).toLongLong();
-
-        if (key == u"total") {
-            total = value;
-            hasTotal = true;
-        } else if (key == u"upload" || key == u"download") {
-            used += value;
-        } else if (key == u"expire") {
-            expire = value;
+    if (sub.expire > 0) {
+        qint64 now = QDateTime::currentSecsSinceEpoch();
+        if (sub.isExpired()) {
+            parts << QObject::tr("Expired (%1)").arg(DisplayTime(sub.expire, QLocale::ShortFormat));
+        } else {
+            qint64 diffSecs = sub.expire - now;
+            if (diffSecs < 86400) {
+                qint64 diffHours = std::max<qint64>(1, diffSecs / 3600);
+                parts << QObject::tr("Expires in %1h (%2)").arg(diffHours).arg(DisplayTime(sub.expire, QLocale::ShortFormat));
+            } else {
+                qint64 diffDays = diffSecs / 86400;
+                parts << QObject::tr("Expires in %1d (%2)").arg(diffDays).arg(DisplayTime(sub.expire, QLocale::ShortFormat));
+            }
         }
     }
 
-    if (!hasTotal)
-        return {};
+    if (updateIntervalHours > 0) {
+        parts << QObject::tr("Auto-update: %1h").arg(updateIntervalHours);
+    }
 
-    return QObject::tr("Used: %1 Remain: %2 Expire: %3")
-        .arg(ReadableSize(used),
-             total == 0 ? QString::fromUtf8("\u221E")
-                        : ReadableSize(total - used),
-             DisplayTime(expire, QLocale::ShortFormat));
+    return parts.join(" | ");
 }
 
 GroupItem::GroupItem(QWidget *parent, const std::shared_ptr<Configs::Group> &ent, QListWidgetItem *item) : QWidget(parent), ui(new Ui::GroupItem) {
@@ -86,8 +80,8 @@ void GroupItem::refresh_data() {
         if (ent->sub_last_update != 0) {
             info << tr("Last update: %1").arg(DisplayTime(ent->sub_last_update, QLocale::ShortFormat));
         }
-        auto subinfo = ParseSubInfo(ent->info);
-        if (!ent->info.isEmpty()) {
+        auto subinfo = ParseSubInfo(ent->info, ent->sub_update_interval);
+        if (!subinfo.isEmpty()) {
             info << subinfo;
         }
         if (info.isEmpty()) {

--- a/src/ui/group/dialog_edit_group.cpp
+++ b/src/ui/group/dialog_edit_group.cpp
@@ -12,7 +12,6 @@
 #include "include/database/GroupsRepo.h"
 #include "include/database/ProfilesRepo.h"
 
-
 #define ADJUST_SIZE runOnThread([=,this] { adjustSize(); adjustPosition(mainwindow); }, this);
 
 DialogEditGroup::DialogEditGroup(const std::shared_ptr<Configs::Group> &ent, QWidget *parent) : QDialog(parent), ui(new Ui::DialogEditGroup) {
@@ -28,6 +27,12 @@ DialogEditGroup::DialogEditGroup(const std::shared_ptr<Configs::Group> &ent, QWi
     ui->auto_clear_unavailable->setChecked(ent->auto_clear_unavailable);
     ui->skip_auto_update->setChecked(ent->skip_auto_update);
     ui->url->setText(ent->url);
+
+    ui->sub_update_interval->setRange(0, 720);
+    ui->sub_update_interval->setValue(ent->sub_update_interval);
+    ui->sub_update_interval->setSpecialValueText(tr("Default (Auto / Global)"));
+    ui->sub_update_interval->setSuffix(tr(" hours"));
+
     ui->type->setCurrentIndex(ent->url.isEmpty() ? 0 : 1);
     ui->type->currentIndexChanged(ui->type->currentIndex());
     ui->cat_share->setVisible(false);
@@ -216,6 +221,7 @@ void DialogEditGroup::accept() {
     ent->auto_clear_unavailable = ui->auto_clear_unavailable->isChecked();
     ent->url = ui->url->text().trimmed();
     ent->skip_auto_update = ui->skip_auto_update->isChecked();
+    ent->sub_update_interval = ui->sub_update_interval->value();
     ent->front_proxy_id = resolve_proxy_selection(ui->front_proxy, CACHE.front_proxy);
     ent->landing_proxy_id = resolve_proxy_selection(ui->landing_proxy, LANDING.landing_proxy);
     QDialog::accept();

--- a/src/ui/mainWindow/mainwindow_groups.cpp
+++ b/src/ui/mainWindow/mainwindow_groups.cpp
@@ -11,7 +11,7 @@
 #include "include/ui/group/dialog_edit_group.h"
 #include "include/ui/mainWindow/MainWindowInternal.h"
 #include "include/ui/mainWindow/TestRunner.h"
-
+#include "include/global/Utils.hpp"
 
 void MainWindow::on_tabWidget_currentChanged(int index) {
     if (Configs::dataManager->settingsRepo->refreshing_group_list) return;
@@ -42,6 +42,57 @@ void MainWindow::show_group(int gid) {
     }
 
     ui->tabWidget->widget(groupId2TabIndex(gid))->layout()->addWidget(ui->profilesTableView);
+
+    // Update top bar subscription card
+    if (m_subInfoCard != nullptr) {
+        m_subInfoCard->setGroup(group);
+    }
+    UpdateDataView(true);
+
+    // Update tab tooltip
+    int tabIdx = groupId2TabIndex(gid);
+    if (tabIdx >= 0 && group != nullptr) {
+        auto subInfo = group->GetSubUserInfo();
+        QString title = subInfo.title.isEmpty() ? group->name : subInfo.title;
+
+        if (group->url.isEmpty()) {
+            ui->tabWidget->setTabToolTip(tabIdx, title);
+        } else {
+            QString html = QStringLiteral("<div style='max-width:320px;line-height:1.3;'>");
+            html += QStringLiteral("<b>%1</b><br>").arg(title.toHtmlEscaped());
+            html += QStringLiteral("<span style='opacity:0.8;'>%1</span><br>").arg(tr("Type: Subscription"));
+
+            if (group->sub_last_update > 0) {
+                html += QStringLiteral("%1: %2<br>").arg(tr("Last updated"), DisplayTime(group->sub_last_update, QLocale::ShortFormat));
+            }
+            if (group->sub_update_interval > 0) {
+                html += QStringLiteral("%1: every %2h<br>").arg(tr("Auto-update"), QString::number(group->sub_update_interval));
+            }
+            if (subInfo.valid) {
+                html += QStringLiteral("%1: %2<br>").arg(tr("Used"), ReadableSize(subInfo.used()));
+                if (subInfo.total > 0) {
+                    html += QStringLiteral("%1: %2 (%3: %4)<br>").arg(
+                        tr("Total"), ReadableSize(subInfo.total), tr("Remaining"), ReadableSize(subInfo.remaining()));
+                }
+                if (subInfo.expire > 0) {
+                    html += QStringLiteral("%1: %2<br>").arg(tr("Expires"), DisplayTime(subInfo.expire, QLocale::ShortFormat));
+                }
+                if (!subInfo.support_url.isEmpty()) {
+                    html += QStringLiteral("%1: %2<br>").arg(tr("Support"), subInfo.support_url.toHtmlEscaped());
+                }
+                if (!subInfo.web_url.isEmpty()) {
+                    html += QStringLiteral("%1: %2<br>").arg(tr("Portal"), subInfo.web_url.toHtmlEscaped());
+                }
+                if (!subInfo.announce.isEmpty()) {
+                    html += QStringLiteral("<div style='margin-top:4px;padding-top:4px;border-top:1px solid rgba(128,128,128,0.3);'><b>%1:</b><br>%2</div>")
+                        .arg(tr("Announcement"), subInfo.announce.toHtmlEscaped());
+                }
+            }
+            html += QStringLiteral("</div>");
+            ui->tabWidget->setTabToolTip(tabIdx, html);
+        }
+    }
+
 
     refresh_proxy_list({}, true);
 

--- a/src/ui/mainWindow/mainwindow_setup.cpp
+++ b/src/ui/mainWindow/mainwindow_setup.cpp
@@ -5,6 +5,7 @@
 #include "include/ui/mainWindow/TestRunner.h"
 
 #include <QMenu>
+#include <QStackedWidget>
 
 #include "include/configs/sub/GroupUpdater.hpp"
 #include "include/configs/sub/RouteUpdater.hpp"
@@ -23,6 +24,7 @@
 #include "include/ui/stats/dialog_traffic_stats.h"
 #include "include/ui/stats/dialog_runtime_stats.h"
 #include "include/ui/widget/StartStopButton.hpp"
+#include "include/ui/widget/SubscriptionInfoCard.hpp"
 
 #include "include/configs/generate.h"
 #include "include/database/GroupsRepo.h"
@@ -382,6 +384,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 
             switch (index)
             {
+            case ConnectionsTableModel::ColSource:   sortType = Stats::BySource; break;
             case ConnectionsTableModel::ColProcess:  sortType = Stats::ByProcess; break;
             case ConnectionsTableModel::ColProtocol: sortType = Stats::ByProtocol; break;
             case ConnectionsTableModel::ColOutbound: sortType = Stats::ByOutbound; break;
@@ -676,6 +679,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     });
     connect(filterHeader, &ProfilesTableFilterHeader::focusTableRequested, this,
             [this](bool selectFirst) { focusProfilesTable(selectFirst); });
+
+    // (Page 0: Subscription Card, Page 1: Live test reports)
+    m_topBarStack = new QStackedWidget(this);
+    m_subInfoCard = new SubscriptionInfoCard(this);
+
+    ui->horizontalLayout_2->removeWidget(ui->data_view);
+    m_topBarStack->addWidget(m_subInfoCard);
+    m_topBarStack->addWidget(ui->data_view);
+    ui->horizontalLayout_2->addWidget(m_topBarStack);
 
     this->refresh_groups();
 
@@ -1109,4 +1121,3 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
 MainWindow::~MainWindow() {
     delete ui;
 }
-

--- a/src/ui/mainWindow/mainwindow_setup.cpp
+++ b/src/ui/mainWindow/mainwindow_setup.cpp
@@ -1076,20 +1076,19 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     connect(Stats::autoSelectorMonitor, &Stats::AutoSelectorMonitor::updated, this,
             [this] { refresh_auto_selector_view(); }, Qt::QueuedConnection);
 
-    {
+{
         auto* runner = Throne::PeriodicRunner::instance();
-        // Interval is sign-encoded in settings (negative = disabled); < 30 min counts as off.
-        const auto minutesOf = [](int v) { return v >= 30 ? v : 0; };
+        static qint64 lastSubCheck = 0;
         runner->Add({
-            tr("subscriptions"),
-            [minutesOf] { return minutesOf(Configs::dataManager->settingsRepo->sub_auto_update); },
-            [] { return Configs::dataManager->settingsRepo->sub_auto_update_last; },
+            "",
+            [] { return 10; }, 
+            [] { return lastSubCheck; },
             [](qint64 t) {
-                Configs::dataManager->settingsRepo->sub_auto_update_last = t;
-                Configs::dataManager->settingsRepo->Save();
+                lastSubCheck = t;
             },
-            [] { Subscription::updater()->RefreshAll(true); },
+            [] { Subscription::updater()->CheckAutoUpdate(); },
         });
+        const auto minutesOf = [](int v) { return v >= 30 ? v : 0; };
         runner->Add({
             tr("routing profiles"),
             [minutesOf] { return minutesOf(Configs::dataManager->settingsRepo->route_auto_update); },

--- a/src/ui/mainWindow/mainwindow_view.cpp
+++ b/src/ui/mainWindow/mainwindow_view.cpp
@@ -12,6 +12,7 @@
 #include "include/database/ProfilesRepo.h"
 #include "include/database/RoutesRepo.h"
 #include "include/database/SettingsRepo.h"
+#include "include/global/LocalNetwork.hpp"
 #include "include/stats/autoselector/AutoSelectorMonitor.hpp"
 #include "include/ui/setting/Icon.hpp"
 #include "include/ui/stats/dialog_auto_selector.h"
@@ -67,7 +68,21 @@ void MainWindow::UpdateDataView(bool force)
     }
     auto html = dataViewHtmlGenerator_.buildHtml();
     runOnUiThread([=, this] {
-        ui->data_view->setHtml(html);
+        if (m_topBarStack != nullptr) {
+            if (!html.isEmpty()) {
+                // Active Speedtest / URL test / Download report -> Show data_view
+                m_topBarStack->setCurrentWidget(ui->data_view);
+                ui->data_view->setHtml(html);
+            } else {
+                // Idle -> Show native Subscription card
+                m_topBarStack->setCurrentWidget(m_subInfoCard);
+                if (auto group = Configs::dataManager->groupsRepo->CurrentGroup()) {
+                    m_subInfoCard->setGroup(group);
+                }
+            }
+        } else {
+            ui->data_view->setHtml(html);
+        }
     }, true);
     lastUpdatedMs.store(QDateTime::currentMSecsSinceEpoch());
 }
@@ -155,10 +170,19 @@ void MainWindow::refresh_status(const QString &traffic_update) {
         }
         ui->label_running->setText(runningLabelText);
     }
-    const auto display_socks = DisplayAddress(settings->inbound_address, settings->inbound_socks_port);
     const auto inbound_disabled = settings->disable_mixed_inbound;
-    const auto inbound_txt = QString("Mixed: %1").arg(inbound_disabled ? "Disabled" : display_socks);
-    ui->label_inbound->setText(inbound_txt);
+    auto display_socks = DisplayAddress(settings->inbound_address, settings->inbound_socks_port);
+    QString inbound_tip;
+    // A wildcard bind is not something a LAN client can dial, so show the interface it actually reaches instead.
+    if (!inbound_disabled && LocalNetwork::LanInboundIsWildcard()) {
+        if (const auto lan = LocalNetwork::LanAddress(); !lan.isEmpty()) {
+            inbound_tip = tr("Listening on all interfaces (%1)").arg(display_socks);
+            display_socks = DisplayAddress(lan, settings->inbound_socks_port);
+        }
+    }
+    ui->label_inbound->setText(QString("Mixed: %1").arg(inbound_disabled ? "Disabled" : display_socks));
+    ui->label_inbound->setToolTip(inbound_tip);
+    syncConnectionSourceColumn();
     ui->checkBox_VPN->setChecked(settings->spmode_vpn);
     ui->checkBox_SystemProxy->setChecked(settings->spmode_system_proxy);
     if (select_mode) {

--- a/src/ui/widget/SubscriptionInfoCard.cpp
+++ b/src/ui/widget/SubscriptionInfoCard.cpp
@@ -1,0 +1,459 @@
+#include "include/ui/widget/SubscriptionInfoCard.hpp"
+
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QLabel>
+#include <QProgressBar>
+#include <QToolButton>
+#include <QDesktopServices>
+#include <QUrl>
+#include <QApplication>
+#include <QPainter>
+#include <QPainterPath>
+#include <QFontMetrics>
+#include <QResizeEvent>
+
+#include "include/database/entities/Group.h"
+#include "include/database/GroupsRepo.h"
+#include "include/configs/sub/GroupUpdater.hpp"
+#include "include/ui/setting/ThemeManager.hpp"
+#include "include/global/GuiUtils.hpp"
+#include "include/global/Utils.hpp"
+#include "include/global/Configs.hpp"
+
+namespace
+{
+    QPixmap renderVectorPixmap(const QString &kind, const QColor &color, int size = 14)
+    {
+        QPixmap pix(size, size);
+        pix.fill(Qt::transparent);
+        QPainter p(&pix);
+        p.setRenderHint(QPainter::Antialiasing, true);
+        QPen pen(color, 1.25, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin);
+        p.setPen(pen);
+        p.setBrush(Qt::NoBrush);
+
+        if (kind == "globe")
+        {
+            p.drawEllipse(QRectF(1.2, 1.2, 11.6, 11.6));
+            p.drawLine(QPointF(1.5, 7.0), QPointF(12.5, 7.0));
+            p.drawEllipse(QRectF(4.4, 1.2, 5.2, 11.6));
+        }
+        else if (kind == "chat")
+        {
+            QPainterPath path;
+            path.addRoundedRect(QRectF(1.2, 1.5, 11.6, 8.5), 2.0, 2.0);
+            path.moveTo(3.5, 10.0);
+            path.lineTo(2.0, 12.8);
+            path.lineTo(6.5, 10.0);
+            p.drawPath(path);
+            p.drawLine(QPointF(3.8, 4.5), QPointF(10.2, 4.5));
+            p.drawLine(QPointF(3.8, 7.0), QPointF(8.2, 7.0));
+        }
+        else if (kind == "hourglass")
+        {
+            p.setPen(Qt::NoPen);
+            p.setBrush(color);
+            p.drawRoundedRect(QRectF(2.0, 1.0, 10.0, 1.6), 0.6, 0.6);
+            p.drawRoundedRect(QRectF(2.0, 11.4, 10.0, 1.6), 0.6, 0.6);
+
+            p.setPen(pen);
+            p.setBrush(Qt::NoBrush);
+            QPainterPath glass;
+            glass.moveTo(3.4, 2.6);
+            glass.lineTo(10.6, 2.6);
+            glass.cubicTo(QPointF(10.0, 4.8), QPointF(8.2, 5.8), QPointF(8.0, 7.0));
+            glass.cubicTo(QPointF(8.2, 8.2), QPointF(10.0, 9.2), QPointF(10.6, 11.4));
+            glass.lineTo(3.4, 11.4);
+            glass.cubicTo(QPointF(4.0, 9.2), QPointF(5.8, 8.2), QPointF(6.0, 7.0));
+            glass.cubicTo(QPointF(5.8, 5.8), QPointF(4.0, 4.8), QPointF(3.4, 2.6));
+            p.drawPath(glass);
+
+            p.setPen(Qt::NoPen);
+            p.setBrush(color);
+            QPainterPath sand;
+            sand.moveTo(4.6, 10.8);
+            sand.lineTo(9.4, 10.8);
+            sand.lineTo(8.2, 8.4);
+            sand.lineTo(5.8, 8.4);
+            sand.closeSubpath();
+            p.drawPath(sand);
+
+            p.setPen(pen);
+            p.drawLine(QPointF(7.0, 6.2), QPointF(7.0, 8.4));
+        }
+        else if (kind == "warn")
+        {
+            QPolygonF tri;
+            tri << QPointF(7.0, 1.2) << QPointF(13.2, 12.5) << QPointF(0.8, 12.5);
+            p.drawPolygon(tri);
+            p.drawLine(QPointF(7.0, 4.8), QPointF(7.0, 8.2));
+            p.drawPoint(QPointF(7.0, 10.5));
+        }
+        else if (kind == "info")
+        {
+            p.drawEllipse(QRectF(1.5, 1.5, 11.0, 11.0));
+            p.setPen(Qt::NoPen);
+            p.setBrush(color);
+            p.drawEllipse(QRectF(6.1, 3.5, 1.8, 1.8));
+            p.drawRoundedRect(QRectF(6.2, 6.2, 1.6, 4.0), 0.6, 0.6);
+        }
+
+        p.end();
+        return pix;
+    }
+}
+
+SubscriptionInfoCard::SubscriptionInfoCard(QWidget *parent)
+    : QFrame(parent)
+{
+    setupUi();
+    applyTheme();
+
+    connect(themeManager(), &ThemeManager::themeChanged, this, [this](const QString &)
+            {
+        applyTheme();
+        updateData(); });
+
+    connect(Subscription::updater(), &Subscription::GroupUpdater::asyncUpdateCallback, this, [this](int gid)
+            {
+        if (m_group && (gid < 0 || m_group->id == gid)) {
+            auto freshGroup = Configs::dataManager->groupsRepo->GetGroup(m_group->id);
+            if (freshGroup != nullptr) {
+                setGroup(freshGroup);
+            }
+        } });
+}
+
+void SubscriptionInfoCard::setupUi()
+{
+    setObjectName(QStringLiteral("SubscriptionInfoCard"));
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+
+    auto *rootLayout = new QVBoxLayout(this);
+    rootLayout->setContentsMargins(4, 1, 4, 1);
+    rootLayout->setSpacing(2);
+
+    auto *row1 = new QHBoxLayout();
+    row1->setContentsMargins(0, 0, 0, 0);
+    row1->setSpacing(3);
+    row1->setAlignment(Qt::AlignVCenter);
+
+    m_titleLabel = new QLabel(this);
+    QFont titleFont = m_titleLabel->font();
+    titleFont.setBold(true);
+    titleFont.setPointSize(8);
+    m_titleLabel->setFont(titleFont);
+    m_titleLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_titleLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    row1->addWidget(m_titleLabel, 1);
+
+    m_expiryIcon = new QLabel(this);
+    m_expiryIcon->setFixedSize(13, 13);
+    m_expiryLabel = new QLabel(this);
+    QFont expFont = m_expiryLabel->font();
+    expFont.setPointSize(8);
+    m_expiryLabel->setFont(expFont);
+    m_expiryLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+
+    row1->addWidget(m_expiryIcon);
+    row1->addWidget(m_expiryLabel);
+    row1->addSpacing(10);
+
+    auto createButton = [this](const QString &tooltip) -> QToolButton *
+    {
+        auto *btn = new QToolButton(this);
+        btn->setFixedSize(22, 18);
+        btn->setToolTip(tooltip);
+        btn->setCursor(Qt::PointingHandCursor);
+        return btn;
+    };
+
+    m_btnPortal = createButton(tr("Website / Portal"));
+    connect(m_btnPortal, &QToolButton::clicked, this, [this]
+            {
+        if (m_group) {
+            auto sub = m_group->GetSubUserInfo();
+            if (!sub.web_url.isEmpty()) QDesktopServices::openUrl(QUrl(sub.web_url));
+        } });
+    m_btnPortal->hide();
+    row1->addWidget(m_btnPortal);
+
+    m_btnSupport = createButton(tr("Technical Support"));
+    connect(m_btnSupport, &QToolButton::clicked, this, [this]
+            {
+        if (m_group) {
+            auto sub = m_group->GetSubUserInfo();
+            if (!sub.support_url.isEmpty()) QDesktopServices::openUrl(QUrl(sub.support_url));
+        } });
+    m_btnSupport->hide();
+    row1->addWidget(m_btnSupport);
+
+    rootLayout->addLayout(row1);
+
+    m_progressBar = new QProgressBar(this);
+    m_progressBar->setFixedHeight(15);
+    m_progressBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    m_progressBar->setTextVisible(true);
+    m_progressBar->setAlignment(Qt::AlignCenter);
+    rootLayout->addWidget(m_progressBar);
+
+    m_bottomRow = new QFrame(this);
+    m_bottomRow->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    auto *row3 = new QHBoxLayout(m_bottomRow);
+    row3->setContentsMargins(0, 0, 0, 0);
+    row3->setSpacing(6);
+    row3->setAlignment(Qt::AlignVCenter);
+
+    m_bottomLabel = new QLabel(m_bottomRow);
+    QFont btmFont = m_bottomLabel->font();
+    btmFont.setPointSize(8);
+    m_bottomLabel->setFont(btmFont);
+    m_bottomLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    row3->addWidget(m_bottomLabel, 1);
+
+    m_btnAnnounceMore = createButton(tr("View full announcement"));
+    m_btnAnnounceMore->setFixedSize(18, 16);
+    connect(m_btnAnnounceMore, &QToolButton::clicked, this, [this]
+            {
+        if (m_group) {
+            auto sub = m_group->GetSubUserInfo();
+            if (!sub.announce.isEmpty()) {
+                QString title = !sub.title.isEmpty() ? sub.title : m_group->name;
+                MessageBoxScrollable(tr("Announcement - %1").arg(title), sub.announce);
+            }
+        } });
+    m_btnAnnounceMore->hide();
+    row3->addWidget(m_btnAnnounceMore);
+
+    rootLayout->addWidget(m_bottomRow);
+}
+
+bool SubscriptionInfoCard::hasSubscription() const
+{
+    return m_group != nullptr && !m_group->url.isEmpty();
+}
+
+void SubscriptionInfoCard::setGroup(const std::shared_ptr<Configs::Group> &group)
+{
+    m_group = group;
+    updateData();
+}
+
+void SubscriptionInfoCard::resizeEvent(QResizeEvent *event)
+{
+    QFrame::resizeEvent(event);
+    updateAnnouncementLayout();
+}
+
+void SubscriptionInfoCard::updateAnnouncementLayout()
+{
+    if (m_fullAnnounce.isEmpty())
+    {
+        m_bottomRow->hide();
+        return;
+    }
+
+    m_bottomRow->show();
+    QFontMetrics fm(m_bottomLabel->font());
+
+    int availWidth = m_bottomRow->width() - 16;
+    if (availWidth <= 50)
+        return;
+
+    QString fullTextWithBullet = QStringLiteral("• %1").arg(m_fullAnnounce);
+    int fullWidth = fm.horizontalAdvance(fullTextWithBullet);
+
+    if (fullWidth <= availWidth)
+    {
+        m_bottomLabel->setText(fullTextWithBullet);
+        m_btnAnnounceMore->hide();
+    }
+    else
+    {
+        m_btnAnnounceMore->show();
+        int btnWidth = m_btnAnnounceMore->width() > 0 ? m_btnAnnounceMore->width() : 18;
+        int textAvailWidth = availWidth - btnWidth - 10;
+
+        QString elided = fm.elidedText(m_fullAnnounce, Qt::ElideRight, textAvailWidth);
+        m_bottomLabel->setText(QStringLiteral("• %1").arg(elided));
+    }
+}
+
+void SubscriptionInfoCard::updateData()
+{
+    if (!hasSubscription())
+    {
+        hide();
+        return;
+    }
+
+    auto sub = m_group->GetSubUserInfo();
+    const auto &tk = themeManager()->tokens;
+    const QColor winBg = qApp->palette().color(QPalette::Active, QPalette::Window);
+    const bool isDark = (winBg.lightness() <= 128);
+
+    const QString textPrimary = isDark ? QStringLiteral("#F3F4F6") : QStringLiteral("#111827");
+    const QString textSecondary = isDark ? QStringLiteral("#D1D5DB") : QStringLiteral("#374151");
+    const QString trackColor = isDark ? QStringLiteral("#1E2630") : QStringLiteral("#E9ECEF");
+    const QString borderColor = isDark ? QStringLiteral("#455364") : QStringLiteral("#CBD5E1");
+
+    QString title = !sub.title.isEmpty() ? sub.title : m_group->name;
+    m_titleLabel->setText(title);
+    m_titleLabel->setStyleSheet(QStringLiteral("color: %1;").arg(textPrimary));
+
+    if (sub.expire > 0)
+    {
+        qint64 now = QDateTime::currentSecsSinceEpoch();
+        qint64 diffSecs = sub.expire - now;
+        qint64 diffDays = diffSecs / 86400;
+
+        if (sub.isExpired())
+        {
+            m_expiryIcon->setPixmap(renderVectorPixmap("warn", tk.danger, 13));
+            m_expiryLabel->setText(tr("Expired"));
+            m_expiryLabel->setStyleSheet(QStringLiteral("color: %1; font-weight: bold;").arg(tk.danger.name()));
+        }
+        else if (diffSecs < 86400)
+        {
+            qint64 hours = std::max<qint64>(1, diffSecs / 3600);
+            m_expiryIcon->setPixmap(renderVectorPixmap("warn", tk.danger, 13));
+            m_expiryLabel->setText(QStringLiteral("%1h left").arg(hours));
+            m_expiryLabel->setStyleSheet(QStringLiteral("color: %1; font-weight: bold;").arg(tk.danger.name()));
+        }
+        else if (diffDays <= 3)
+        {
+            m_expiryIcon->setPixmap(renderVectorPixmap("warn", tk.danger, 13));
+            m_expiryLabel->setText(QStringLiteral("%1d left").arg(diffDays));
+            m_expiryLabel->setStyleSheet(QStringLiteral("color: %1; font-weight: bold;").arg(tk.danger.name()));
+        }
+        else
+        {
+            m_expiryIcon->setPixmap(renderVectorPixmap("hourglass", QColor(textSecondary), 13));
+            m_expiryLabel->setText(QStringLiteral("%1d left").arg(diffDays));
+            m_expiryLabel->setStyleSheet(QStringLiteral("color: %1;").arg(textSecondary));
+        }
+        m_expiryIcon->show();
+        m_expiryLabel->show();
+    }
+    else
+    {
+        m_expiryIcon->setPixmap(renderVectorPixmap("hourglass", QColor(textSecondary), 13));
+        m_expiryLabel->setText(QStringLiteral("∞ left"));
+        m_expiryLabel->setStyleSheet(QStringLiteral("color: %1;").arg(textSecondary));
+        m_expiryIcon->show();
+        m_expiryLabel->show();
+    }
+
+    const bool hasWeb = !sub.web_url.isEmpty() && (sub.web_url.startsWith("http://", Qt::CaseInsensitive) || sub.web_url.startsWith("https://", Qt::CaseInsensitive));
+    const bool hasSupport = !sub.support_url.isEmpty() && (sub.support_url.startsWith("http://", Qt::CaseInsensitive) || sub.support_url.startsWith("https://", Qt::CaseInsensitive));
+    m_btnPortal->setVisible(hasWeb);
+    m_btnSupport->setVisible(hasSupport);
+
+    QString usedStr = ReadableSize(sub.used());
+    QString totalStr = (sub.total > 0) ? ReadableSize(sub.total) : QString::fromUtf8("∞");
+    double pct = sub.percentUsed();
+
+    QString barColor;
+    if (sub.isExpired() || pct >= 90.0)
+        barColor = tk.danger.name();
+    else if (pct >= 75.0)
+        barColor = tk.tag.name();
+    else if (pct >= 50.0)
+        barColor = tk.accent.name();
+    else
+        barColor = tk.success.name();
+
+    if (sub.total > 0)
+    {
+        m_progressBar->setRange(0, 100);
+        m_progressBar->setValue(static_cast<int>(pct));
+        m_progressBar->setFormat(QStringLiteral("%1 / %2 (%3%)").arg(usedStr, totalStr, QString::number(static_cast<int>(pct))));
+    }
+    else
+    {
+        m_progressBar->setRange(0, 100);
+        m_progressBar->setValue(100);
+        m_progressBar->setFormat(QStringLiteral("%1 / ∞").arg(usedStr));
+    }
+
+    m_progressBar->setStyleSheet(QStringLiteral(
+                                     "QProgressBar {"
+                                     "  border: 1px solid %1;"
+                                     "  border-radius: 4px;"
+                                     "  text-align: center;"
+                                     "  font-weight: bold;"
+                                     "  font-size: 7.5pt;"
+                                     "  line-height: 1;"
+                                     "  color: %2;"
+                                     "  background-color: %3;"
+                                     "}"
+                                     "QProgressBar::chunk {"
+                                     "  background-color: %4;"
+                                     "  border-radius: 3px;"
+                                     "}")
+                                     .arg(borderColor, (pct >= 50.0 && sub.total > 0) ? QStringLiteral("#FFFFFF") : textPrimary, trackColor, barColor));
+    const QString cleanAnnounce = sub.announce.trimmed();
+    const bool hasAnnounce = !cleanAnnounce.isEmpty() && cleanAnnounce.compare("base64:", Qt::CaseInsensitive) != 0;
+
+    if (hasAnnounce)
+    {
+        m_fullAnnounce = cleanAnnounce;
+        m_bottomLabel->setToolTip(cleanAnnounce);
+        m_bottomLabel->setStyleSheet(QStringLiteral("color: %1;").arg(textSecondary));
+        updateAnnouncementLayout();
+    }
+    else
+    {
+        m_fullAnnounce.clear();
+        m_btnAnnounceMore->hide();
+        if (m_group->sub_update_interval > 0)
+        {
+            m_bottomLabel->setText(tr("Auto-update: %1h").arg(m_group->sub_update_interval));
+            m_bottomLabel->setToolTip(QString());
+            m_bottomLabel->setStyleSheet(QStringLiteral("color: %1;").arg(textSecondary));
+            m_bottomRow->show();
+        }
+        else if (m_group->sub_last_update > 0)
+        {
+            m_bottomLabel->setText(tr("Updated: %1").arg(DisplayTime(m_group->sub_last_update, QLocale::ShortFormat)));
+            m_bottomLabel->setToolTip(QString());
+            m_bottomLabel->setStyleSheet(QStringLiteral("color: %1;").arg(textSecondary));
+            m_bottomRow->show();
+        }
+        else
+        {
+            m_bottomRow->hide();
+        }
+    }
+
+    show();
+}
+
+void SubscriptionInfoCard::applyTheme()
+{
+    const auto &tk = themeManager()->tokens;
+    const QColor winBg = qApp->palette().color(QPalette::Active, QPalette::Window);
+    const bool isDark = (winBg.lightness() <= 128);
+
+    const QString chipBg = isDark ? QStringLiteral("#1E293B") : QStringLiteral("#F1F5F9");
+    const QString chipBorder = isDark ? QStringLiteral("#334155") : QStringLiteral("#CBD5E1");
+
+    setStyleSheet(QStringLiteral(
+                      "QFrame#SubscriptionInfoCard { background: transparent; border: none; }"
+                      "QToolButton {"
+                      "  background-color: %1;"
+                      "  border: 1px solid %2;"
+                      "  border-radius: 4px;"
+                      "  padding: 1px;"
+                      "}"
+                      "QToolButton:hover {"
+                      "  background-color: %3;"
+                      "  border-color: %4;"
+                      "}")
+                      .arg(chipBg, chipBorder, tk.hoverFill.name(), tk.accent.name()));
+
+    m_btnPortal->setIcon(QIcon(renderVectorPixmap("globe", tk.onSurface, 13)));
+    m_btnSupport->setIcon(QIcon(renderVectorPixmap("chat", tk.onSurface, 13)));
+    m_btnAnnounceMore->setIcon(QIcon(renderVectorPixmap("info", tk.onSurface, 14)));
+}


### PR DESCRIPTION
### Summary
Closes #1653.

The goal is to parse subscription headers (`Subscription-Userinfo`, `profile-update-interval`, `Profile-Title`, `Support-Url`, `Announce`, etc.) sent by panels like 3x-ui and Marzban, implement the profile update interval sent by the server (if sent), and display the quota/metadata in the UI. 

Changes are split into two commits (logic/UI).

---

### Commit 1: `feat(sub): add subscription userinfo parsing and profile-update-interval`

* **`include/database/entities/Group.h` & `src/database/entities/Group.cpp`**
  * Added `SubUserInfo` struct and `ParseSubUserInfo()` to parse upload, download, total, and expiry.
  * Added `sub_update_interval` to `Group` (0 = default/auto, >0 = custom hours).
  * Parses title, web/support URLs, and announcements.

* **`src/database/GroupsRepo.cpp`**
  * Added `sub_update_interval` column to the `groups` SQLite table with an `ALTER TABLE` migration check for existing databases.
  * Added serialization in `saveToDatabase`, `loadFromDatabase`, and JSON helpers.

* **`include/configs/sub/GroupUpdater.hpp` & `src/configs/sub/GroupUpdater.cpp`**
  * Added `decodeHeaderValue()` to handle base64-prefixed headers.
  * Added `ParseUpdateInterval()` to parse `profile-update-interval`.
  * Updated `fetch()` to extract headers and in-body comment fallbacks (`#subscription-userinfo:`, etc.).
  * Updated `refresh()` to save the metadata, adopt the server interval if unset, and adopt the title if the group name was just the URL host.
  * Added `CheckAutoUpdate()` to check group intervals and dispatch background refreshes via `RefreshGroup()`.

* **`include/ui/group/dialog_edit_group.ui` & `src/ui/group/dialog_edit_group.cpp`**
  * Added an `Update Interval` spinbox.

* **`src/ui/group/GroupItem.cpp`**
  * Updated `ParseSubInfo()` to use the new parser, display sub-day expiry (`3h left`), and show the auto-update interval.

* **`src/ui/mainWindow/mainwindow_setup.cpp`**
  * Replaced the blunt global `RefreshAll()` runner with a 10-minute silent check calling `Subscription::updater()->CheckAutoUpdate()`, enabling per-group interval scheduling.

---

### Commit 2: `feat(ui): implement SubscriptionInfoCard`

* **`include/ui/widget/SubscriptionInfoCard.hpp` & `src/ui/widget/SubscriptionInfoCard.cpp`**
  * New native widget replacing the top-right text view.
  * Line 1: Group title on the left, countdown and action buttons on the right.
  * Line 2: 15px `QProgressBar` spanning the full width with centered text (`used / total`).
  * Line 3: Displays the announcement directly at the bottom. Uses `QFontMetrics` and `resizeEvent` to elide text dynamically. If no announcement exists, it shows the auto-update interval.
  * Vector icons drawn in code (`renderVectorPixmap`) to match theme colors.

* **`CMakeLists.txt`**
  * Added `SubscriptionInfoCard` files to `PROJECT_SOURCES`.

* **`include/ui/mainwindow.h`**
  * Added `m_topBarStack` (`QStackedWidget`) and `m_subInfoCard` members.

* **`src/ui/mainWindow/mainwindow_setup.cpp`**
  * Swapped `ui->data_view` in the top toolbar with `m_topBarStack`, containing `m_subInfoCard` (Page 0) and `ui->data_view` (Page 1).

* **`src/ui/mainWindow/mainwindow_view.cpp`**
  * Updated `UpdateDataView()` to show `ui->data_view` when speed/URL tests or downloads are running, and flip back to `m_subInfoCard` when idle.

* **`src/ui/mainWindow/mainwindow_groups.cpp`**
  * Sets the group on `m_subInfoCard` on group switch.
  * Announcement tooltip with word-wrapped HTML (`max-width: 320px`) so long announcements don't stretch into a single wide line across the screen.

---

### Screenshots
<img width="1485" height="631" alt="image" src="https://github.com/user-attachments/assets/67dd58ee-0b16-4926-a387-e4691bbdb885" />
<img width="1477" height="627" alt="image" src="https://github.com/user-attachments/assets/3a3bef3b-cdca-40fd-af51-91780d5e9cc8" />
<img width="793" height="629" alt="image" src="https://github.com/user-attachments/assets/fb28306e-16d7-4fde-91d7-a441422969d5" />
<img width="796" height="630" alt="image" src="https://github.com/user-attachments/assets/4b943a36-bf8c-489f-8b88-e30778f16b08" />

Test build: https://github.com/VindEi/Throne/actions/runs/34113079607